### PR TITLE
Added import of pipeline variable group 'Version'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ pool:
 
 variables:
 - group: Code-signing-variables
+- group: Version
 
 name: $(buildNumberMajor).$(buildNumberMinor)$(Rev:.rrrr)
 


### PR DESCRIPTION
This variable group was defined on Azure under the NO-BN pipeline library, availbale to all pipelines for NO-BN.