### PR TITLE
JBTKO_SST Sporstopper 3d

### DIFF
--- a/NO-BN/DNA/_SRC/NO-BN-TrackAndWaysideObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-TrackAndWaysideObjects.xml
@@ -1124,7 +1124,7 @@
 		<xpp:expand select="NOBN_com_DISCIPLINE___TRK"/>
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS"/>
 		<xpp:expand select="NOBN_com_SET_OCP_STATION_REFERENCE"/>
-		<xpp:expand select="NOBN_com_STD_LUAEXPRESSIONS___TRACKBOUND_OBJECT_NO_3D"/>
+		<xpp:expand select="NOBN_com_STD_LUAEXPRESSIONS___TRACKBOUND_OBJECT"/>
 		<xpp:expand select="NOBN_com_STD_LUAEXPRESSIONS___EARTHED_TO_NONE"/>
 		<xpp:expand select="NOBN_com_PSET_BANE_NOR"/>
 		<xpp:expand select="NOBN_com_PSET_FDV_BANEDATA"/>


### PR DESCRIPTION
ValidateDNA gives the following errors:

![image](https://github.com/Railcomplete-AS/RailCOMPLETE-DNA-NO-BN/assets/33001939/c2b0a746-efdb-4c09-b163-8c21ce7ddf65)

The reason is that "JBTKO_SST Sporstopper" doesn't have a Geometry3D dynamic property, which is again because NOBN_com_STD_LUAEXPRESSIONS___TRACKBOUND_OBJECT_NO_3D naturally doesn't have any 3D:

![image](https://github.com/Railcomplete-AS/RailCOMPLETE-DNA-NO-BN/assets/33001939/74815521-9904-4fd9-b033-9abd02e0e339)

I think that the fix is just to replace NOBN_com_STD_LUAEXPRESSIONS___TRACKBOUND_OBJECT_NO_3D with NOBN_com_STD_LUAEXPRESSIONS___TRACKBOUND_OBJECT .

The two macros look like this:

![image](https://github.com/Railcomplete-AS/RailCOMPLETE-DNA-NO-BN/assets/33001939/d2d3d0ad-f154-4b4b-b9d0-896b06969be4)

If that is right then this pull request can be accepted.