### PR TITLE
Fix: Position tool cleanup

### DIFF
--- a/NO-BN/DNA/_SRC/NO-BN-PositionToolSettings.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-PositionToolSettings.xml
@@ -48,20 +48,17 @@
 <PositionToolSettings Name="NOBN_PositionToolSettings">
   	<PositionToolTextLines>
 		<!-- TODO: Add NOBN version of Long/Lat. offset outside alignment's geometry <OwnAlignmentOffset OrderPriority="8" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_Offset_Own"/> -->
- 		<OwnAlignmentNameOrCodeOrId				OrderPriority="6" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_AlignmentName_Own"/>
+ 		<OwnAlignmentNameOrCodeOrId				PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_AlignmentName_Own"/> <!-- Don't set order priority, it will go to the top by default. -->
 		<OwnAlignmentDistanceToAlignment		OrderPriority="4" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_DistanceToAlignment_Own"/>
 		<OwnAlignmentElevation					OrderPriority="3" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_Elevation_Own"/>
-<!-- TODO: Deprecate <OwnAlignmentPos> => <OwnAlignmentDistanceAlong> -->
-  		<OwnAlignmentPos						OrderPriority="2" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_DistanceAlong_Own"/>
+  		<OwnAlignmentPos						OrderPriority="2" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_DistanceAlong_Own"/> <!-- Will be deprecated in favor of OwnAlignmentDistanceAlong in RC 2026.2 -->
   		<OwnAlignmentMileage					OrderPriority="1" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_Mileage_Own"/>
 		
 		<!-- TODO: Add NOBN version of Long/Lat. offset outside alignment's geometry <ReferenceAlignmentOffset OrderPriority="7" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_Offset_Ref"/> -->
-		<ReferenceAlignmentNameOrCodeOrId		OrderPriority="5" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_AlignmentName_Ref"/>
-  		<!-- <ReferenceAlignmentDistanceToAlignment> is not used because it would be confusing -->
+		<ReferenceAlignmentNameOrCodeOrId		PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_AlignmentName_Ref"/> <!-- Don't set order priority, it will go to the top by default. -->
 		<ReferenceAlignmentElevation			OrderPriority="3" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_Elevation_Ref"/>
-<!-- TODO: Deprecate <ReferenceAlignmentPos> => <ReferenceAlignmentDistanceAlong> -->
-  		<ReferenceAlignmentPos						OrderPriority="2" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_DistanceAlong_Ref"/>
-  		<ReferenceAlignmentMileage					OrderPriority="1" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_Km"/>
+  		<ReferenceAlignmentPos					OrderPriority="2" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_DistanceAlong_Ref"/> <!-- Will be deprecated in favor of ReferenceAlignmentDistanceAlong in RC 2026.2 -->
+  		<ReferenceAlignmentMileage				OrderPriority="1" PositionToolFormatLuaFunctionName="NOBN_trk_PositionTransient_Set_Km"/>
   	</PositionToolTextLines>
 </PositionToolSettings>
 


### PR DESCRIPTION
- Removed wrong OrderPriorities from header information.
- Removed commented out items that don't exist in C#.
- Clarified some comments.