### PR TITLE
docs: add Claude Code Lua skills and references

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -166,6 +166,22 @@ AutoLISP source in `NO-BN\2D\_SRC\Main\`:
 
 Subdirectories contain the actual symbol-drawing LISP routines per discipline.
 
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>: <short summary>
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `chore`, `style`, `test`, `build`, `ci`.
+
+Examples:
+- `feat: add signal distance calculation script`
+- `fix: correct gradient lookup in ATC target distances`
+- `docs: update CLAUDE.md with commit conventions`
+- `refactor: simplify Lua function naming in signals XML`
+
 ## Branch Strategy
 - **develop**: Active development, may contain work-in-progress
 - **main**: Stable releases, triggers Azure CI/CD pipeline

--- a/.claude/references/050-commands.html
+++ b/.claude/references/050-commands.html
@@ -1,0 +1,1876 @@
+<!DOCTYPE html>
+<html class="writer-html5" lang="en" >
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="author" content="Railcomplete AS" />
+      <link rel="shortcut icon" href="img/favicon.ico" />
+    <title>RailCOMPLETE commands - RailCOMPLETE Reference Manual</title>
+    <link rel="stylesheet" href="css/theme.css" />
+    <link rel="stylesheet" href="css/theme_extra.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" />
+        <link href="extra.css" rel="stylesheet" />
+    
+      <script>
+        // Current page data
+        var mkdocs_page_name = "RailCOMPLETE commands";
+        var mkdocs_page_input_path = "050-commands.md";
+        var mkdocs_page_url = null;
+      </script>
+    
+    <!--[if lt IE 9]>
+      <script src="js/html5shiv.min.js"></script>
+    <![endif]-->
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/lua.min.js"></script>
+      <script>hljs.highlightAll();</script> 
+</head>
+
+<body class="wy-body-for-nav" role="document">
+
+  <div class="wy-grid-for-nav">
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
+    <div class="wy-side-scroll">
+      <div class="wy-side-nav-search">
+<a href="./index.html" class="icon icon-home"> RailCOMPLETE Reference Manual</a><div role="search">
+  <form id ="rtd-search-form" class="wy-form" action="./search.html" method="get">
+      <input type="text" name="q" placeholder="Search docs" aria-label="Search docs" title="Type search term here" />
+  </form>
+</div>
+      </div>
+
+      <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
+    
+		<div style="display: inline-block;">
+												
+					
+					<a href="./050-commands.html">
+						<img style="height: 15px;" alt="English" src="./img/flags/en.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./fr/050-commands.html">
+						<img style="height: 15px;" alt="Français" src="./img/flags/fr.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./de/050-commands.html">
+						<img style="height: 15px;" alt="Deutsch" src="./img/flags/de.png" />
+					</a>
+					
+				
+
+			</div>
+		
+    
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="index.html">Welcome</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="010-gettingstarted.html">Getting started</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="020-mainfeatures.html">Main features</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="030-tipsandtricks.html">Tips and tricks</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="035-LinearReferencing.html">Linear Referencing</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="040-qa.html">Q&A</a>
+				</li>
+			</ul>
+			<ul class="current">
+				<li class="toctree-l1 current"><a class="reference internal current" href="050-commands.html">RailCOMPLETE commands</a>
+    <ul class="current">
+    <li class="toctree-l2"><a class="reference internal" href="#rc-about">RC-About</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-activatecontextualribbontabs">RC-ActivateContextualRibbonTabs</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-creatednamapping">RC-AGENT-CreateDnaMapping</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-forceredrawsymbols">RC-AGENT-ForceRedrawSymbols</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-loaddnafromxml">RC-AGENT-LoadDnaFromXml</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-peekatdna">RC-AGENT-PeekAtDna</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-peekatobjectdefinition">RC-AGENT-PeekAtObjectDefinition</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-peekattabledefinition">RC-AGENT-PeekAtTableDefinition</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-reloaddnafromdrawing">RC-AGENT-ReloadDnaFromDrawing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-reloadtooltipfiles">RC-AGENT-ReloadTooltipFiles</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-replacednaindrawing">RC-AGENT-ReplaceDnaInDrawing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-resetlayers">RC-AGENT-ResetLayers</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-resetluaformulas">RC-AGENT-ResetLuaFormulas</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-validatedna">RC-AGENT-ValidateDna</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-agent-writesymbolthumbnailstofile">RC-AGENT-WriteSymbolThumbnailsToFile</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-assistassignverticalprofile">RC-AssistAssignVerticalProfile</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-assistcreateearthing">RC-AssistCreateEarthing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-assistcreateinterlockingdata">RC-AssistCreateInterlockingData</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#requirements">Requirements</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#output">Output</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#custom-interlocking-tables">Custom Interlocking Tables</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-assistinsertconnectionobjects">RC-AssistInsertConnectionObjects</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-assistinsertgeometryandprofileannotationobjects">RC-AssistInsertGeometryAndProfileAnnotationObjects</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-assistsetalignmentmileageinheritance">RC-AssistSetAlignmentMileageInheritance</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-attachxref">RC-AttachXRef</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-auditalignments">RC-AuditAlignments</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-auditconnectionobjects">RC-AuditConnectionObjects</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-auditrelations">RC-AuditRelations</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-auditsections">RC-AuditSections</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-audituniqueids">RC-AuditUniqueIDs</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-addobjecttoschematicdrawing">RC-BETA-AddObjectToSchematicDrawing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-approximatepolylinebyarcsandtangents">RC-BETA-ApproximatePolylineByArcsAndTangents</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-assistcreateschematicdrawing">RC-BETA-AssistCreateSchematicDrawing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-assistinsertalignmentusingregression">RC-BETA-AssistInsertAlignmentUsingRegression</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-auditconnections">RC-BETA-AuditConnections</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-auditschematicdrawing">RC-BETA-AuditSchematicDrawing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-drawrailmlinfrastructurevisualization">RC-BETA-DrawRailmlInfrastructureVisualization</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-dumpschematicobjectinfo">RC-BETA-DumpSchematicObjectInfo</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-exporttorailml">RC-BETA-ExportToRailml</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-beta-removerailmlattributesoftypeany">RC-BETA-RemoveRailmlAttributesOfTypeAny</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-bindtoselectedalignment">RC-BindToSelectedAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-bindxref">RC-BindXRef</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-breakalignment">RC-BreakAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-browsecommands">RC-BrowseCommands</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-copyannotationsalongpathstodrawing">RC-CopyAnnotationsAlongPathsToDrawing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-copyannotationstodrawing">RC-CopyAnnotationsToDrawing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-copybrakingcurvetoclipboard">RC-CopyBrakingCurveToClipboard</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-copypositiontoclipboard">RC-CopyPositionToClipboard</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-copyselectionalongpath">RC-CopySelectionAlongPath</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-create3dtextstyle">RC-Create3DTextStyle</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-deferrefresh">RC-DeferRefresh</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-detachxref">RC-DetachXRef</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-disablecontextualribbontabs">RC-DisableContextualRibbonTabs</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-display2dalignmentatelevation">RC-Display2dAlignmentAtElevation</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-displaybrakingcurveebicab700">RC-DisplayBrakingCurveEbicab700</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-displayenvelope">RC-DisplayEnvelope</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-displaygauge">RC-DisplayGauge</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-displaysighting">RC-DisplaySighting</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-editballoongroupsequence">RC-EditBalloonGroupSequence</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-editinterlockingdatasettings">RC-EditInterlockingDataSettings</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-editproperty">RC-EditProperty</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-editscript">RC-EditScript</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-edittable">RC-EditTable</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-edittextattributes">RC-EditTextAttributes</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-export2dprojections">RC-Export2dProjections</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-export2dprojectionsusingcurrentsettings">RC-Export2dProjectionsUsingCurrentSettings</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-export3d">RC-Export3d</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-export3dusingcurrentsettings">RC-Export3dUsingCurrentSettings</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-exportalignmentstolandxml">RC-ExportAlignmentsToLandxml</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-exportreferencealignmentdefinitionstoxml">RC-ExportReferenceAlignmentDefinitionsToXml</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-exporttabletoexcel">RC-ExportTableToExcel</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-groupballoons">RC-GroupBalloons</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-help">RC-Help</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-importalignmentsfromlandxml">RC-ImportAlignmentsFromLandxml</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-importpolylinesfromdwg">RC-ImportPolylinesFromDwg</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-importreferencealignmentdefinitionsfromxml">RC-ImportReferenceAlignmentDefinitionsFromXml</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-insert3dpreview">RC-Insert3DPreview</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-insertalignment">RC-InsertAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-insertarea">RC-InsertArea</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-insertpointobject">RC-InsertPointObject</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-insertpredefinedtable">RC-InsertPredefinedTable</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-inserttable">RC-InsertTable</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-joinalignments">RC-JoinAlignments</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-loadribbon">RC-LoadRibbon</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-loadsymbollibraryfromdwg">RC-LoadSymbolLibraryFromDwg</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-managealignments">RC-ManageAlignments</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-managedrawinglibrary">RC-ManageDrawingLibrary</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-managelicense">RC-ManageLicense</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-manageobjects">RC-ManageObjects</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-manageproject">RC-ManageProject</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-manageproperties">RC-ManageProperties</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-managepropertysetdefinitions">RC-ManagePropertySetDefinitions</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-managestagesusinglayernames">RC-ManageStagesUsingLayerNames</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-matchdynamicproperties">RC-MatchDynamicProperties</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-matchformulas">RC-MatchFormulas</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-matchposition">RC-MatchPosition</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-moveselectionalongpath">RC-MoveSelectionAlongPath</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-movetextattributes">RC-MoveTextAttributes</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-offsetalignment">RC-OffsetAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-offsetprofile">RC-OffsetProfile</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-opengeneraltutorialsfolder">RC-OpenGeneralTutorialsFolder</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-openlogfile">RC-OpenLogFile</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-opennationaltutorialsfolder">RC-OpenNationalTutorialsFolder</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-openxref">RC-OpenXRef</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-quantizeposition">RC-QuantizePosition</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-queryobject">RC-QueryObject</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-quickselect">RC-QuickSelect</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-refreshinterlockingdata">RC-RefreshInterlockingData</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-refreshobjects">RC-RefreshObjects</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-refreshtable">RC-RefreshTable</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-reloadallxrefs">RC-ReloadAllXRefs</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-reloadxref">RC-ReloadXRef</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-removeinvalidluaexpressions">RC-RemoveInvalidLuaExpressions</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-removepaths">RC-RemovePaths</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-reorganizeribbontodefault">RC-ReorganizeRibbonToDefault</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-reversealignment">RC-ReverseAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-rotateucsandview">RC-RotateUcsAndView</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-runpatches">RC-RunPatches</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-runscript">RC-RunScript</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-selectsimilar">RC-SelectSimilar</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-set2dalignmentdisplayelevation">RC-Set2dAlignmentDisplayElevation</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-set2dalignmentdisplayelevationfrompointobject">RC-Set2dAlignmentDisplayElevationFromPointObject</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setalignmentpropertyinpointobject">RC-SetAlignmentPropertyInPointObject</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setnationaltooltipposition">RC-SetNationalTooltipPosition</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpath">RC-SetPath</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpathsfromarea">RC-SetPathsFromArea</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpositiontoolalignmentfilter">RC-SetPositionToolAlignmentFilter</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpositiontooldistancealongdisplaymode">RC-SetPositionToolDistanceAlongDisplayMode</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpositiontooldistancetoalignmentdisplaymode">RC-SetPositionToolDistanceToAlignmentDisplayMode</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpositiontoolquantizationmode">RC-SetPositionToolQuantizationMode</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpositiontoolreferencealignmentmode">RC-SetPositionToolReferenceAlignmentMode</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setpositiontoolverticalprofiledisplaymode">RC-SetPositionToolVerticalProfileDisplayMode</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setreferencealignment">RC-SetReferenceAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-setrelationrefreshdepth">RC-SetRelationRefreshDepth</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-settings">RC-Settings</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-show2dprojection3dsourcepreview">RC-Show2dProjection3dSourcePreview</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-show2dprojectionboxpreview">RC-Show2dProjectionBoxPreview</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-show2dprojectionpreview">RC-Show2dProjectionPreview</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-show3dpreview">RC-Show3dPreview</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showalignmentgeometry">RC-ShowAlignmentGeometry</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showalignmentmileage">RC-ShowAlignmentMileage</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showalignmentname">RC-ShowAlignmentName</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showalignmentprofile">RC-ShowAlignmentProfile</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showannotationinfo">RC-ShowAnnotationInfo</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showdnareleasenotes">RC-ShowDnaReleaseNotes</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showearthing">RC-ShowEarthing</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showfoulingpoints">RC-ShowFoulingPoints</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showinsertionpointinheritance">RC-ShowInsertionPointInheritance</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showlayergroups">RC-ShowLayerGroups</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showmileagechange">RC-ShowMileageChange</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showownalignment">RC-ShowOwnAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showposition">RC-ShowPosition</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showreferencealignment">RC-ShowReferenceAlignment</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showreferencealignmentmileage">RC-ShowReferenceAlignmentMileage</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showrelations">RC-ShowRelations</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showsections">RC-ShowSections</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showtworails">RC-ShowTwoRails</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showversion">RC-ShowVersion</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showvideos">RC-ShowVideos</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-showwarningincadtextwindow">RC-ShowWarningInCadTextWindow</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-support">RC-Support</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-ungroupballoons">RC-UngroupBalloons</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-unloadxref">RC-UnloadXRef</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-updatearea">RC-UpdateArea</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-updatednawithmapping">RC-UpdateDnaWithMapping</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-webpagesandfaq">RC-WebPagesAndFAQ</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-xrefselectoff">RC-XRefSelectOff</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#rc-xrefselecton">RC-XRefSelectOn</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#refedit">REFEDIT</a>
+    </li>
+    </ul>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="060-export3d.html">Export 3D</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="070-lua.html">Lua</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="080-luacommands.html">Lua Functions</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="080-luadebugger.html">Lua debugger</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="090-classdiagrams.html">Class Diagrams</a>
+				</li>
+			</ul>
+      </div>
+    </div>
+    </nav>
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+      <nav class="wy-nav-top" role="navigation" aria-label="Mobile navigation menu">
+          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+          <a href="index.html">RailCOMPLETE Reference Manual</a>
+        
+      </nav>
+      <div class="wy-nav-content">
+        <div class="rst-content"><div role="navigation" aria-label="breadcrumbs navigation">
+  <ul class="wy-breadcrumbs">
+    <li><a href="index.html" class="icon icon-home" aria-label="Docs"></a></li>
+      <li class="breadcrumb-item active">RailCOMPLETE commands</li>
+    <li class="wy-breadcrumbs-aside">
+    </li>
+  </ul>
+  <hr/>
+</div>
+          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+            <div class="section" itemprop="articleBody">
+              
+                <h1 id="railcomplete-commands">RailCOMPLETE commands</h1>
+<p>In this section, all available RailCOMPLETE commands with description are listed.</p>
+<h2 id="rc-about">RC-About</h2>
+<p>Opens the RailCOMPLETE® About window.</p>
+<p>The About window displays the version number, the license information, the end user license agreement (EULA) and 3rd party licenses, and the release notes.</p>
+<h2 id="rc-activatecontextualribbontabs">RC-ActivateContextualRibbonTabs</h2>
+<p>Reloads the table and XRef ribbon bar.</p>
+<h2 id="rc-agent-creatednamapping">RC-AGENT-CreateDnaMapping</h2>
+<p>Creates a mapping, a translation, between the source DNA contained in your current RailCOMPLETE document and the selected target DNA.</p>
+<p>The two DNA versions are compared, and the differences are displayed by the mapping tool. For each object type declared in the source DNA, you define how its properties, enum values and relations will be translated into the corresponding entities in the target DNA.</p>
+<p>A DNA mapping specifies how for instance property <em>OldPropertyName</em> will be translated into property <em>NewPropertyName</em>, how enum values <em>[red | green | blue]</em> will be translated into <em>[color0 | color1 | color 2 ]</em> and how relation <em>[Is coupled with switch]</em> will be translated into <em>[Is coupled with turnout]</em>.</p>
+<p>Making a complete DNA mapping requires knowledge about the source and the target DNA's interpretations, and is usually taking care of by the Agent that proposes a new DNA version. A mapping should be provided for all existing DNA versions into the new DNA. Note that it is possible to update an old document with several 'DNA jumps' or intermediate steps.</p>
+<p>Partial DNA mappings can be made in case the RailCOMPLETE document to be mapped contains only a limited number of object types.</p>
+<p>The command provides <em>conditional mapping</em> to handle the mapping of different variants of one object into multiple objects. For instance, when an object of type X with variants A, B, C and D is mapped to two objects of types X1 and X2, with X1 holding variants A and B, and X2 variants C and D. In this case, both the Type and Variant of the source object will be taken into account when translating the object's data to comply with the new DNA's object type declarations.</p>
+<h2 id="rc-agent-forceredrawsymbols">RC-AGENT-ForceRedrawSymbols</h2>
+<p>Forces the update of the symbols of placed objects.</p>
+<h2 id="rc-agent-loaddnafromxml">RC-AGENT-LoadDnaFromXml</h2>
+<p>Loads a new DNA from the selected XML file and sets it as the current active DNA in computer memory, without affecting the stored drawing or the objects’ current status in memory.</p>
+<p>The current DNA in memory determines how new objects are inserted into the drawing.</p>
+<p>When switching active document (CAD system drawing) to a RailCOMPLETE document, the DNA is automatically re-loaded from the drawing.</p>
+<p>It is recommended to first make a backup of your drawing.</p>
+<h2 id="rc-agent-peekatdna">RC-AGENT-PeekAtDna</h2>
+<p>Peek at the DNA file defining how new objects are created, interrelated and represented symbolically.</p>
+<p>The Definition of Network Assets (DNA) is an XML file containing the 'genetic' information of the objects needed for a given railway administration, that is their detailed description.</p>
+<p>Warning: The tool is meant to view the drawing’s 'genetic information'. Edition is possible, but strongly discouraged unless you are an expert user. Please consult the RailCOMPLETE Agent’s User Manual.</p>
+<p>The DNA contains an identification header, a detailed description of all objects needed for a given railway administration, with symbols, properties, methods, relations and create-time default values, and information about items such as fonts, linetypes, and default file system folders.</p>
+<p><strong>1. Built-in objects, properties and methods</strong></p>
+<p>The DNA contains several types of generic objects: point objects (zero dimension), alignment objects (one dimension) and area objects (two dimensions). These object types are available with a multitude of properties and methods. Examples of common basic properties are the object’s id, name, description, distance along a specified alignment, its relative elevation and its distance to this alignment. An alignment may be a track’s center line, a road center line, a cable duct, a catenary wire etc. The built-in methods can manipulate the object in 3D space, associate it with a 3D model, draw poles between boards and foundations, etc. Built-in methods are also available for obtaining information from the alignment that a point object has been connected to, such as elevation, gradient, curvature and cant.</p>
+<p><strong>2. Object declaration and specialization</strong></p>
+<p>Specialized objects are declared in the DNA, starting out with one of the generic object types available, and adding as many custom properties and methods as needed. Each object type declares its own Attachment Category and its affinities for other such categories, allowing such an object instance to attach to another suitable object and thereby become part of a daisy-chain of physical object positions in 3D space.</p>
+<p>Each object type also declares its own Relation Source Space, allowing it to be logically related to other objects. The DNA can hold an arbitrary number of binary relations.</p>
+<p>Every object type can be declared with several Variants, each with its own recognizable 2D CAD symbol. For each variant there may be several custom properties influencing the object’s description, such as width, length, height, number, color etc. Each relevant combination of custom property values can be associated with a 3D model for this object.</p>
+<p><strong>3. Using standard values and methods</strong></p>
+<p>When an object is created, standard values declared in the DNA can be assigned to the object properties. For instance: a board’s standard elevation above its foundation, or an axle counter’s standard placement at +/-0,75m from track center line, etc.</p>
+<p>In many cases there are no definite values to standardize on in the DNA, but there may still be standard methods. For example: a balise will always be mounted in the center track, but it must be lifted to half of the local track superelevation, as well as pitched with the local track gradient and rolled with the local track cant. In switches you may even find balises that are yawed in relation to their track’s center line, because the sleepers may follow the switch’s other leg’s orientation. In such a case, the DNA will declare a formula to be evaluated for the relevant property (just as you would do in a spreadsheet). The superelevation formula would read something like <code>getAlignmentInfo().Superelevation/2000</code>, assuming that superelevation is expressed in millimeters, and applied to the object’s Z-coordinate property.</p>
+<h2 id="rc-agent-peekatobjectdefinition">RC-AGENT-PeekAtObjectDefinition</h2>
+<p>Peek at the XML code behind a RailCOMPLETE object.</p>
+<p>Note: Although you can modify an object’s stored definition using this tool, you are strongly advised not to do so unless you are an expert user. Please consult the RailCOMPLETE Agent’s User Manual.</p>
+<h2 id="rc-agent-peekattabledefinition">RC-AGENT-PeekAtTableDefinition</h2>
+<p>Peek at the definition behind a RailCOMPLETE table.</p>
+<p>Note: Although you can modify a table’s stored definition using this tool, you are strongly advised not to do so unless you are an expert user. Please consult the RailCOMPLETE Agent’s User Manual.</p>
+<h2 id="rc-agent-reloaddnafromdrawing">RC-AGENT-ReloadDnaFromDrawing</h2>
+<p>Loads the DNA saved in the drawing and sets it as the current active DNA in computer memory.</p>
+<p>The current DNA in memory determines how new objects are inserted into the drawing.</p>
+<p>When switching to another RailCOMPLETE document, the DNA is automatically re-loaded from that drawing.</p>
+<p>After loading a new DNA, you must run <a href="050-commands.html#rc-agent-replacednaindrawing">RC-AGENT-ReplaceDnaInDrawing</a> to apply the new DNA to the drawing's objects and to make the new DNA permanent in the drawing.</p>
+<h2 id="rc-agent-reloadtooltipfiles">RC-AGENT-ReloadTooltipFiles</h2>
+<p>LuaTooltips_ReloadToolTipFiles_1</p>
+<p>LuaTooltips_ReloadToolTipFiles_2</p>
+<h2 id="rc-agent-replacednaindrawing">RC-AGENT-ReplaceDnaInDrawing</h2>
+<p>Replaces the current DNA contained in the drawing with the selected DNA.</p>
+<p>This option allows rapid prototyping of DNA modifications, without having to create a DNA mapping. It is recommended to first make a backup of your drawing, and use this option only when small differences exist between the two DNA versions. If major differences exist between the current DNA and its replacement version, use instead the option Update DNA With Mapping.</p>
+<p>You must remember to run this command after loading a DNA from DWG or from XML to apply the new DNA to the drawing, thereby updating its objects.</p>
+<p>Examples of situation in which this option is useful and relatively safe:</p>
+<ul>
+<li>
+<p>Small variations to Lua code inside the DNA, such as changes to text strings or local variable names.</p>
+</li>
+<li>
+<p>New properties added to existing object types.</p>
+</li>
+<li>
+<p>New object types added. No existing object types or properties will be deprecated.</p>
+</li>
+<li>
+<p>New relations added. No existing relation data can become inaccessible.</p>
+</li>
+<li>
+<p>Change of cardinality for an existing relation.</p>
+</li>
+</ul>
+<p>Examples of changes where this Replace DNA option may harm your model:</p>
+<ul>
+<li>
+<p>Modification of the name of an object type Existing objects with the deprecated name will become inaccessible.</p>
+</li>
+<li>
+<p>Modification of the name of an object type's properties.</p>
+</li>
+<li>
+<p>Modification of the name, the call syntax or the return value in a DNA-declared Lua function.</p>
+</li>
+<li>
+<p>Modification of the name of an existing relation.</p>
+</li>
+<li>
+<p>Removal of a relation.</p>
+</li>
+</ul>
+<p>In such cases, use the option Update DNA With Mapping <a href="050-commands.html"></a>.</p>
+<h2 id="rc-agent-resetlayers">RC-AGENT-ResetLayers</h2>
+<p>Updates the layer properties for all layers affected by the selected 2D symbol(s), resetting them according to the current document’s DNA.</p>
+<p>Layers which are unaltered will retain their current on/off and thawed/frozen states. Layers which are (re-)introduced will be set to their default state according to the DNA.</p>
+<h2 id="rc-agent-resetluaformulas">RC-AGENT-ResetLuaFormulas</h2>
+<p>Updates the Lua formulas in the selected objects according to their object type definition.</p>
+<p>Model checks will also be redefined.</p>
+<h2 id="rc-agent-validatedna">RC-AGENT-ValidateDna</h2>
+<p>Checks the integrity of a DNA file.</p>
+<p>Checks for XML errors, duplicate definitions, Lua errors and more.</p>
+<p>ValidateDna is a user-friendly interface comprising a file selector for loading the definition file (DNA) and a data grid that displays validation results. The data grid has three columns: line number, error/warning message, and the contents of the XML file at the line number.</p>
+<p><strong><em>Validation Checks</em></strong></p>
+<p>ValidateDNA performs the following checks to ensure the integrity and correctness of the file according to the DNA schema:</p>
+<p><strong><em>1. Unknown Element/Attribute</em></strong></p>
+<p>Checks for elements and attributes not defined in our DNA schema and other XML errors.</p>
+<p><strong><em>2. Deprecation Check</em></strong></p>
+<p>Identifies deprecated elements or attributes, providing replacement suggestions and the deprecation date where applicable.</p>
+<p><strong><em>3. Duplicate Layers</em></strong></p>
+<p>Detects <code>Layer</code> elements that have an identical <code>Name</code> attribute.</p>
+<p><strong><em>4. Duplicate Show Layers</em></strong></p>
+<p>Detects <code>ShowLayer</code> elements that have an identical <code>Name</code> attribute.</p>
+<p><strong><em>5. Lua Function Inconsistency</em></strong></p>
+<p>Verifies consistency in <code>LuaFunction</code> elements across the <code>Name</code> attribute, <code>Signature</code> element, and <code>Formula</code> element. It also checks for their existence.</p>
+<p><strong><em>6. Duplicate Lua Functions</em></strong></p>
+<p>Detects <code>LuaFunction</code> elements that have an identical <code>Name</code> attribute.</p>
+<p><strong><em>7. Duplicate Relation Definitions</em></strong></p>
+<p>Detects <code>Relation</code> elements that have an identical <code>Name</code> attribute.</p>
+<p><strong><em>8. Lua Function Syntax Errors</em></strong></p>
+<p>Validates the syntax of each <code>LuaFunction</code>'s function definition. This check does not cover run-time errors.</p>
+<p><strong><em>9. Valid Side of Alignment Definitions</em></strong></p>
+<p>Ensures the correctness of each <code>SideOfAlignmentInterval</code> according to several rules concerning interval validity.</p>
+<p><strong><em>10. Duplicate Formula Definition</em></strong></p>
+<p>Detects <code>LuaExpression</code>s mapped to the same property (identical names).</p>
+<p><strong><em>11. Duplicate Lua Aliases</em></strong></p>
+<p>Ensures each <code>ObjectType</code>'s <code>LuaName</code> and each <code>Relation</code>'s <code>ForwardLuaName</code> and <code>ReverseLuaName</code> are distinct and valid Lua variable names.</p>
+<p><strong><em>12. Bad SetValues</em></strong></p>
+<p>Checks for any <code>ObjectType</code>'s <code>SetValue</code>s and <code>LuaExpression</code>s that don't map to a property. Applies the same check for every <code>ObjectType</code>'s <code>Variant</code>s.</p>
+<p><strong><em>13. Duplicate Custom Properties</em></strong></p>
+<p>Detects <code>CustomProperty</code> elements that have an identical <code>Name</code> attribute.</p>
+<h2 id="rc-agent-writesymbolthumbnailstofile">RC-AGENT-WriteSymbolThumbnailsToFile</h2>
+<p>Generates a file containing symbol thumbnails.</p>
+<h2 id="rc-assistassignverticalprofile">RC-AssistAssignVerticalProfile</h2>
+<p>Assigns a vertical profile to an alignment by interpolation.</p>
+<p>Given two alignments S (start) and E (end), and a connecting alignment C between them this command assigns a vertical profile to C based on S and E.</p>
+<p><img alt="AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand" src="img/CommandDescriptions/AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand_1.png" /></p>
+<p>Three methods are available: Normal, Gradient and Straight.</p>
+<p>This command has the following configurable settings:</p>
+<ul>
+<li>
+<p>Choice of interpolation method,</p>
+</li>
+<li>
+<p>alignment start properties, and</p>
+</li>
+<li>
+<p>alignment end properties.</p>
+</li>
+</ul>
+<p><img alt="AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand" src="img/CommandDescriptions/AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand_2.png" /></p>
+<p>In the explanations below the neighboring alignments are referred to as 'trunk alignments'. This is because 'trunk alignment' is a term commonly used when talking about switches, and switches are typically involved when using this command. Sometimes the explanations suggest that you change some values. These are always settings in the command dropdown menus seen above, not in the vertical profiles themselves.</p>
+<p>Common for all methods is that the connecting alignment inherits the elevation from its neighboring alignments at the connecting points.</p>
+<p><strong>1. Normal method:</strong></p>
+<p>This method is only meaningful if the alignment in question is connected to its neighbors through switches, not continuations. As described below, it tries to copy elevation along the switches and smooth out the middle part. It has the following configurable properties:</p>
+<ul>
+<li>
+<p>Start/end desired smoothing curve radius, and</p>
+</li>
+<li>
+<p>start/end copy length.</p>
+</li>
+</ul>
+<p>The low-mileage and the high-mileage elevation and gradient are copied from the two trunk alignments’ elevation and gradient. If the alignment has connection objects with known geometries at its two trunk alignments, then the vertical profiles are copied from the trunk alignments to the connecting alignment as far as the connection object's geometry goes, provided that they do not overlap. RC then seeks to insert two smoothened PVIs to make the two sets of elevation and gradient meet along the connecting alignment. If the low-mileage PVI's vertical curve end (VCE) would be higher than the high-mileage PVI's vertical curve start (VCS), then the process fails. If the two vertical circular arcs (the PVI smoothenings) don’t overlap, then a tangent segment is inserted between the two circular arcs, and the process succeeds.</p>
+<p>If the process fails, try first to reduce the circular arc radius at each end. If this also fails, try to reduced the length of copying vertical profile from each trunk alignment. A zero copy length corresponds to the Gradient method.</p>
+<p><img alt="AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand" src="img/CommandDescriptions/AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand_3.png" /></p>
+<p><strong>2. Gradient method:</strong></p>
+<p>As described below, this method preserves the elevation gradients at the connecting points by smoothing the vertical profile close to the connection objects. It has the following configurable properties:</p>
+<ul>
+<li>
+<p>Start/end elevation,</p>
+</li>
+<li>
+<p>start/end gradient, and</p>
+</li>
+<li>
+<p>start/end desired smoothing curve radius.</p>
+</li>
+</ul>
+<p>Vertical profile curvature in the trunk tracks at each end of the connecting alignment will be ignored, only the two sets of elevation and gradient will be copied. A vertical circular arc (a smoothened PVI) is inserted at either end of the connecting alignment. The two vertical circular arcs are connected with a tangent line segment (constant gradient).</p>
+<p>If the process fails, try to reduce the vertical circular arc's radius at either end.</p>
+<p><img alt="AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand" src="img/CommandDescriptions/AssistAssignVerticalProfileCommands_AssistAssignVerticalProfileCommand_4.png" /></p>
+<p><strong>3. Straight method:</strong></p>
+<p>As described below, this method performs a linear interpolation. It has the following configurable properties:</p>
+<ul>
+<li>Start/end elevation.</li>
+</ul>
+<p>The two ends of the connecting alignment's vertical profile is connected with a tangent line segment (constant gradient). Elevations are copied from the trunk alignment at each end.</p>
+<h2 id="rc-assistcreateearthing">RC-AssistCreateEarthing</h2>
+<p>Assigns protective earth (PE) to the selected object(s).</p>
+<p>The command automatically selects the PE-providing alignment when no formula is assigned to the EarthingAlignment property of the selected objects. The selection depends on the value of the EarthingMethod property:</p>
+<ul>
+<li>
+<p>If the value is <code>Rail</code>, the closest visible railway track is assigned as PE-providing alignment.</p>
+</li>
+<li>
+<p>If the value is <code>Wire</code>, the closest visible earth wire is assigned.</p>
+</li>
+</ul>
+<p>All selected objects are refreshed.</p>
+<h2 id="rc-assistcreateinterlockingdata">RC-AssistCreateInterlockingData</h2>
+<p>Creates all possible elementary train routes and shunting routes, then exports them to Excel.</p>
+<p>For train routes or shunting routes to be created, the drawing must contain valid signaling objects with non-empty 'code' properties. It must also be possible to draw at least one path between two such signaling objects.</p>
+<p>Which objects are valid signaling objects is governed by Lua scripts found in the command's window.</p>
+<p>This command presents the output data in a particular format. Depending on your drawing's DNA, you may be able to create custom formats using RC tables.</p>
+<p>When you click the 'Export' button, Excel is opened with the route data. It might be hidden behind AutoCAD.</p>
+<h4 id="requirements">Requirements</h4>
+<ul>
+<li>
+<p>The Lua filter formulas in the command window must be configured to detect signals. These normally have DNA defaults, but these defaults don't necessarily fit any given interlocking system. You may have to configure them to suit your needs.</p>
+</li>
+<li>
+<p>The signaling objects in your drawing must match those referenced by the Lua filter formulas. They must also have non-empty 'code' properties.</p>
+</li>
+<li>
+<p>Train detection sections belonging to specific signals must be placed maximally 1 meter away from their respective signals.</p>
+</li>
+</ul>
+<p>Here is an example of how an interlocking Lua filter formula can be configured to match the <code>RcType</code> of a signal:</p>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_1.png" /></p>
+<h4 id="output">Output</h4>
+<p>The command produces an Excel file of train routes, shunting routes, extended train routes and extended shunting routes. Each route has information about start, end and via points, switch positions, conflicting routes and sections.</p>
+<p>The command does not calculate any of the following:</p>
+<ul>
+<li>
+<p>Security zones and overlap</p>
+</li>
+<li>
+<p>Flank protection</p>
+</li>
+<li>
+<p>Local areas</p>
+</li>
+<li>
+<p>Work areas</p>
+</li>
+<li>
+<p>Release of train routes, shunting routes, overlaps, and end points</p>
+</li>
+</ul>
+<p>It also doesn't support administration specific rules.</p>
+<h4 id="custom-interlocking-tables">Custom Interlocking Tables</h4>
+<p>This is an optional feature, separate from the main command.</p>
+<p>If your drawing's DNA contains interlocking tables, you can find them in the insert table menu. When selected, these tables can be recognized by them having two additional buttons in the ribbon: A second refresh button and a settings button.</p>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_2.png" /></p>
+<p>The benefit of using an interlocking table is that you can configure the settings window independently for each table, and that you get control over the output format.</p>
+<p>The interlocking data to be presented in the table is stored in the table object itself. To access it, perform the following steps:</p>
+<ul>
+<li>
+<p>1) Insert an interlocking table in the drawing.</p>
+</li>
+<li>
+<p>2) Configure the interlocking settings using <a href="050-commands.html#rc-editinterlockingdatasettings">RC-EditInterlockingDataSettings</a> if necessary.</p>
+</li>
+<li>
+<p>3) Refresh the table's interlocking data using <a href="050-commands.html#rc-refreshinterlockingdata">RC-RefreshInterlockingData</a>.</p>
+</li>
+<li>
+<p>4) Edit the table using <a href="050-commands.html#rc-edittable">RC-EditTable</a>.</p>
+</li>
+</ul>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_3.png" /></p>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_4.png" /></p>
+<p>When editing the table the following steps are necessary:</p>
+<ul>
+<li>
+<p>1) Set Row Selection to Custom Collection.</p>
+</li>
+<li>
+<p>2) Edit the Custom Collection Lua formula and copy paste the below code. Don't close the Lua editor yet.</p>
+</li>
+</ul>
+<pre><code>
+local interlockingTables = DocumentData.ObjectCollection:filter(function (x) return x.RcType == &quot;Replace with table's RCType&quot; end)
+
+local firstTable = table.firstOrNil(interlockingTables)
+
+
+
+if firstTable then
+
+    return firstTable.Interlocking.Routes
+
+else
+
+    return {}
+
+end
+
+</code></pre>
+<ul>
+<li>
+<p>3) In the code above, replace <code>Replace with table's RcType</code> with the <code>RcType</code> of the table in question. You can find it by opening the property manager and clicking the table. Save and close the Lua editor.</p>
+</li>
+<li>
+<p>4) Configure the table columns to present the information that you want.</p>
+</li>
+</ul>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_5.png" /></p>
+<p>Example of a simple step 4 configuration:</p>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_6.png" /></p>
+<p>It produces an output like this:</p>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_7.png" /></p>
+<p>To be able to perform step 4 correctly the following class diagram may be useful. It's very small, you may have to right click it and select 'Magnify image'. </p>
+<p><img alt="InterlockingCommands_ExportRoutesCommand" src="img/CommandDescriptions/InterlockingCommands_ExportRoutesCommand_8.png" /></p>
+<p>The diagram can be read as follows:</p>
+<ul>
+<li>
+<p>The context of each table row and Lua formula is a <code>Route</code> element. I.e., if you write <code>this</code> in one of the Lua table boxes then a <code>Route</code> is returned.</p>
+</li>
+<li>
+<p>The properties of each <code>Route</code> are those listed in the Route box, as well as the names written on the arrows leaving it.</p>
+</li>
+<li>
+<p>The names on the individual boxes are the <em>types</em> of the entities contained in those properties.</p>
+</li>
+<li>
+<p>→ Therefore, the correct syntax to get the alignment intervals belonging to a route is <code>this.Path.Intervals</code>, not <code>this.RailwayPath.AlignmentInterval</code>.</p>
+</li>
+</ul>
+<h2 id="rc-assistinsertconnectionobjects">RC-AssistInsertConnectionObjects</h2>
+<p>Inserts objects connecting alignments.</p>
+<p>The command connects selected alignments using object types declared in DNA.</p>
+<p>The simplest connection objects are the <strong>alignment continuations</strong>, which are based on the data type 'RailCOMPLETEContinuation'. Such continuations, to be declared in DNA, will allow a path to be set from one alignment and continue over to its continued alignment. Typical uses are railway track continuations, contact wire continuations, electrical cable continuations and cable duct continuations.</p>
+<p><strong>Switches</strong> (turnouts) connect railway track alignments where one track branches off from another. If the branching geometry corresponds locally to one of the switch geometries defined by DNA, then the Variant of the inserted switch object will be set accordingly. Otherwise, a default Variant will be set (the first one mentioned in DNA). Switch objects are based on the 'eSwitch' data type, a remnant from railML.</p>
+<p>The third type of connection object is the <strong>crossing</strong> (simple crossing, single slip switch or double slip switch), based on the 'eCrossing' data type, also a railML remnant. It will be inserted whenever two track alignments cross, without fulfilling the criteria for being a continuation or a switch.</p>
+<p>The pattern recognition algorithm has a number of settings that can be accessed by calling this Assist command without preselected alignments, then right-click to show the dropdown menu with the 'Settings' option. These settings determine how RailCOMPLETE classifies alignment connections as continuations, switches or crossings. Although our engineers have done their best to optimize these settings, you may still experiment with your own tolerances.</p>
+<p>The pattern recognition algorithm ignores the Z coordinate of the involved alignments. A crossing will be detected also when one passes over or under the other. A track will be connected in a turnout even if the trunk or the branch alignment lacks vertical profile data. Cant is also ignored.</p>
+<h2 id="rc-assistinsertgeometryandprofileannotationobjects">RC-AssistInsertGeometryAndProfileAnnotationObjects</h2>
+<p>Inserts section limits along the selected tracks.</p>
+<p>A segment limit object and its related annotation object are inserted for each horizontal segment.</p>
+<h2 id="rc-assistsetalignmentmileageinheritance">RC-AssistSetAlignmentMileageInheritance</h2>
+<p>Assigns mileage parent for the selected alignments. Each alignment inherits the mileage from its parent.</p>
+<p>The algorithm will search the database for candidate alignments. The candidate closest to the selected alignment's endpoints will be taken as the mileage parent. Mileage inheritance through the start point takes precedence over the end point when candidates are present at both extremities.</p>
+<p>The alignment attempts to re-inherit its mileage whenever the mileage parent is updated to ensure data consistency.</p>
+<p>The mileage inheritance can also be edited manually in the Alignment Manager.</p>
+<h2 id="rc-attachxref">RC-AttachXRef</h2>
+<p>Attaches RailCOMPLETE documents to the drawing as XRefs.</p>
+<p>A RailCOMPLETE XRef is created for each attached document.</p>
+<h2 id="rc-auditalignments">RC-AuditAlignments</h2>
+<p>Audits alignment geometry and data consistency.</p>
+<p>The algorithm searches for missing data and fixes some issues during audit.</p>
+<h2 id="rc-auditconnectionobjects">RC-AuditConnectionObjects</h2>
+<p>Audits the configuration of the selected connection objects according to the local geometry and the given connection definitions.</p>
+<h2 id="rc-auditrelations">RC-AuditRelations</h2>
+<p>Audits relations in drawing.</p>
+<p>One-way relations are reconnected if possible.</p>
+<h2 id="rc-auditsections">RC-AuditSections</h2>
+<p>Checks the references for all alignment sections.</p>
+<h2 id="rc-audituniqueids">RC-AuditUniqueIDs</h2>
+<p>Check unicity of id's for all objects.</p>
+<p>Objects with duplicate id's are assigned a new id.</p>
+<h2 id="rc-beta-addobjecttoschematicdrawing">RC-BETA-AddObjectToSchematicDrawing</h2>
+<p>Adds an object from a geographic drawing to an existing schematic drawing.</p>
+<h2 id="rc-beta-approximatepolylinebyarcsandtangents">RC-BETA-ApproximatePolylineByArcsAndTangents</h2>
+<p>Function provided for test purposes only.</p>
+<p>Descriptions and functionality may be incomplete or contain errors.</p>
+<h2 id="rc-beta-assistcreateschematicdrawing">RC-BETA-AssistCreateSchematicDrawing</h2>
+<p>Creates a schematic plan based on the current model.</p>
+<p>The tool adheres to a collection of hard and soft (customizable) constraints to create linear schematic drawings. Hard constraints are the constraints that all drawings must satisfy. Soft constraints are user-controlled optimization criteria.</p>
+<p>The tool is suitable for infrastructure within a single corridor.</p>
+<p>The following hard constraints are first applied:</p>
+<ul>
+<li>
+<p><strong>Octolinearity</strong>: The lines representing tracks are either horizontal or diagonal at 45 degrees.</p>
+</li>
+<li>
+<p><strong>Linear Order</strong>: The reference mileage of locations on the infrastructure is ordered left to right.</p>
+</li>
+<li>
+<p><strong>Node Shapes</strong>: Switches split the track on the trunk side into a left and a right leg on the branch side. Left and right are preserved such that the layout can be traced back to the actual topology.</p>
+</li>
+<li>
+<p><strong>Uniform Horizontal Spacing</strong>: Horizontal lines are drawn on levels, which are at a specific distance from each other. This distance is called the drawing unit.</p>
+</li>
+</ul>
+<p>The hard constraints are usually not sufficient to create a high-quality drawing. The tool offers multiple optimization criteria also called soft constraints:</p>
+<ul>
+<li>
+<p><strong>Height</strong>: Minimizes the total height of the drawing, in drawing units.</p>
+</li>
+<li>
+<p><strong>Width</strong>: Minimizes the total width of the drawing, in drawing units.</p>
+</li>
+<li>
+<p><strong>Bends</strong>: Minimizes the number of edge bends between switches or crossings.</p>
+</li>
+<li>
+<p><strong>Diagonals</strong>: Minimizes the number of diagonal edges (inclined at 45 degrees in the drawing).</p>
+</li>
+<li>
+<p><strong>Main Tracks</strong>: Attempts to make the main tracks straight-lined and close to each other.</p>
+</li>
+<li>
+<p><strong>Short Edges</strong>: Maximizes the number of short edges. These are edges of one drawing unit length.</p>
+</li>
+<li>
+<p><strong>LocalY</strong>: Minimizes the distance between edges that are vertical neighbors. This is an attempt at grouping neighboring lines.</p>
+</li>
+<li>
+<p><strong>LocalX</strong>: Minimizes the distance between nodes that are horizontal neighbors.</p>
+</li>
+</ul>
+<p>The constraints function in the following manner: First the algorithm finds a drawing that satisfies the hard constraints. Then it optimizes over the soft constraints you have selected in the order you have defined. This means that it first considers the first constraint, and then creates a drawing that is maximally good in this respect. Then it proceeds to the next soft constraint and so on, never invalidating what it arrived at in a previous step.</p>
+<p>Let’s illustrate the impact of the order of the criteria in the following example of a railway model with two soft constraints - <em>Height</em> and <em>Width</em>. Let’s assume that, in a schematic drawing of this model, the least possible height is 5, and the least possible width is 10. We also know that, given a height of 5 the least possible width is 14, and given a width of 10 the least possible height is 7. If <em>Height</em> is the first optimization criterion then the solution will be Height 5 and Width 14. If <em>Width</em> is the first optimization criterion, the solution will be Height 7 and Width 10. Which of these is desirable depends on your specific model and your preferences. The optimization method used in this tool cannot arrive at a solution with Height 6 and Width 11.</p>
+<p><em>Note: Not all RailCOMPLETE drawings are compatible with this tool. In particular, the model must have a global Reference Mileage so that every object can be ordered along the horizontal axis of the schematic drawing. The reference mileage cannot contain any chain breaks.</em></p>
+<h2 id="rc-beta-assistinsertalignmentusingregression">RC-BETA-AssistInsertAlignmentUsingRegression</h2>
+<p>Converts a measured line to a sequence of segments using regression.</p>
+<p>This tool takes a sequence of measured points as input and estimates the true segments via piecewise regression. The goal of the algorithm is to produce an alternating sequence of straights/curves and clothoids, yielding a continuous line with continuous first- and second-order derivatives.</p>
+<p>The following parameters are available:</p>
+<ul>
+<li>
+<p><strong>Gaussian Noise</strong>: Attempts to remove noise from the measurements using a Gaussian filter. This averages measured values, producing a smoother curve of input curvatures. The correct value depends on how large the measurement error in the input data is. The default value is 3.</p>
+</li>
+<li>
+<p><strong>Curvature Order</strong>: The algorithm estimates the curvature at each point to decide to which segment type with which parameters a group of input points belong to. A single point p has no curvature, so its neighboring points are used to estimate curvature. This parameter decides how many points in each direction from p are used. The default value is 1, meaning three points are used for finding the curvature at p.</p>
+</li>
+<li>
+<p><strong>Segment Count</strong>: The number of segments in the output line.</p>
+</li>
+<li>
+<p><strong>Clothoid Curvature Change Rate Limit</strong>: Decides the incidence of clothoids in the solution by limiting how quickly they are allowed to change their curvature. The underlying scale is logarithmic, where 0 on the slider corresponds to 1e-20, while 100 corresponds to 1e2. Ideally this value is set such that you get the alternating sequence of straights/curves and clothoids mentioned above. A higher value decreases the number of clothoids in the solution.</p>
+</li>
+<li>
+<p><strong>Arc Curvature Limit</strong>: Decides the incidence of curves/arcs in the solution by limiting their curvature. The underlying scale is logarithmic, where 0 on the slider corresponds to 1e-20, while 100 corresponds to 1e2. Increase this to remove arcs in favor of straights.</p>
+</li>
+</ul>
+<p>Setting all these parameters to useful values can be time consuming, especially for long sequences of measured points. To alleviate this the process can be partly automated. The automation consists of three parts:</p>
+<ol>
+<li>
+<p><strong>Automatic Clothoid Value</strong>: When the solution contains multiple successive clothoids the algorithm may break down. This is especially true if there are successive clothoids at either the start or end of the segment sequence. This option finds the lowest value for the Clothoid Curvature Change Rate Limit such that the segment sequence neither starts nor ends with two clothoids. Note: The correct value could be slightly higher than this value obtained automatically, but is rarely lower.</p>
+</li>
+<li>
+<p><strong>Automatic Arc Value</strong>: Ideally the solution is continuously differentiable, but this is not always so. This option searches through the Arc Curvature Limit values for a solution that is as close as possible to being continuously differentiable.</p>
+</li>
+<li>
+<p><strong>Get Automatic Solution</strong>: This option attempts to automatically produce a acceptable solution by finding useful values for Segment Count, Clothoid Curvature Change Rate Limit and Arc Curvature Limit. The Gaussian Noise Filter Sigma and Curvature Order are left as is. The algorithm starts at a given n and runs both Automatic Clothoid Value and Automatic Curvature Limit, and then checks whether the resulting solution is geographically close to the measure points. It then continues in this manner, finally choosing the solution that is closest to being continuously differentiable. Note that this process can take a long time to complete, especially for long sequences of measure points.</p>
+</li>
+</ol>
+<h2 id="rc-beta-auditconnections">RC-BETA-AuditConnections</h2>
+<p>Checks that railML infrastructure object connections are consistent (two-way connections).</p>
+<h2 id="rc-beta-auditschematicdrawing">RC-BETA-AuditSchematicDrawing</h2>
+<p>Old WIP command for auditing schematic drawings. Not trustworthy.</p>
+<h2 id="rc-beta-drawrailmlinfrastructurevisualization">RC-BETA-DrawRailmlInfrastructureVisualization</h2>
+<p>Draws the schematic representation of the current infrastructure, represented by "clone objects".</p>
+<p>The schematic objects are drawn in the current drawing with respect to the UCS.</p>
+<h2 id="rc-beta-dumpschematicobjectinfo">RC-BETA-DumpSchematicObjectInfo</h2>
+<p>Prints info about selected schematic object.</p>
+<h2 id="rc-beta-exporttorailml">RC-BETA-ExportToRailml</h2>
+<p>Exports objects to railML format.</p>
+<p>The railML export feature is under development and has not yet been certified by railML.org.</p>
+<h2 id="rc-beta-removerailmlattributesoftypeany">RC-BETA-RemoveRailmlAttributesOfTypeAny</h2>
+<p>Removes any railML 'any' elements/attributes from document.</p>
+<h2 id="rc-bindtoselectedalignment">RC-BindToSelectedAlignment</h2>
+<p>Triggers the 'Bind” mode.</p>
+<p>The mileage indicator line will use the last selected alignment (even if deselected) as data source.</p>
+<h2 id="rc-bindxref">RC-BindXRef</h2>
+<p>Converts XRef into a block.</p>
+<p>The XRef becomes a permanent part of the drawing.</p>
+<h2 id="rc-breakalignment">RC-BreakAlignment</h2>
+<p>Breaks one or more alignments.</p>
+<p>Select alignments and define the breaking line with 2 points. The original alignments are erased, and all elements and attached objects are transferred to the new alignments. The original alignment' IDs are re-used for the newly created alignments, by default for the lower mileage part of the split alignment.</p>
+<h2 id="rc-browsecommands">RC-BrowseCommands</h2>
+<p>Opens the Command Browser.</p>
+<p>The command browser is a convenient way to search through all available commands.</p>
+<p><img alt="CommandBrowser_LaunchCommandBrowser" src="img/CommandDescriptions/CommandBrowser_LaunchCommandBrowser.png" /></p>
+<ul>
+<li>
+<p>Search on (part of) the command name or use extended search (1) to search through the command description.</p>
+</li>
+<li>
+<p>Search for the command or description in the search field (2).</p>
+</li>
+<li>
+<p>Use arrow keys to step up/down.</p>
+</li>
+<li>
+<p>Start the command by double-click or by hitting enter on the current command (3).</p>
+</li>
+<li>
+<p>The command description is shown in (4).</p>
+</li>
+</ul>
+<h2 id="rc-copyannotationsalongpathstodrawing">RC-CopyAnnotationsAlongPathsToDrawing</h2>
+<p>Converts transient annotations along current paths to permanent entities in drawing.</p>
+<h2 id="rc-copyannotationstodrawing">RC-CopyAnnotationsToDrawing</h2>
+<p>Converts transient annotations to permanent entities in drawing.</p>
+<h2 id="rc-copybrakingcurvetoclipboard">RC-CopyBrakingCurveToClipboard</h2>
+<p>Copies the last executed braking curve calculation to clipboard.</p>
+<h2 id="rc-copypositiontoclipboard">RC-CopyPositionToClipboard</h2>
+<p>Copies the currently displayed position details to the clipboard.</p>
+<h2 id="rc-copyselectionalongpath">RC-CopySelectionAlongPath</h2>
+<p>Produces copies of the selected group of signals at the desired increment (which may be zero).</p>
+<p>Multiple copies can be made by adjusting the <code>Amount</code> variable. The additional copies will be placed an increment's length away from the previous copy, resulting in an equidistant sequence of copies of an arbitrary size decided by the user.</p>
+<h2 id="rc-create3dtextstyle">RC-Create3DTextStyle</h2>
+<p>Create 3D text styles for converting MTexts to Solids when exporting 3D.</p>
+<p>To create a 3D text style:</p>
+<ul>
+<li>
+<p>Create an AutoCAD style by running the STYLE command, </p>
+</li>
+<li>
+<p>Run this command,</p>
+</li>
+<li>
+<p>Select your AutoCAD style in the drop-down menu,</p>
+</li>
+<li>
+<p>Wait for about 5 minutes while the 3D style is generated, and</p>
+</li>
+<li>
+<p>Save it in the %appdata%\Autodesk\ApplicationPlugins\RC.bundle\Adm[XX-YY]\3D\3DTextStyles folder</p>
+</li>
+</ul>
+<p>About 3D text styles:</p>
+<p>3D text styles are used to convert MTexts to solids in the <a href="050-commands.html#rc-export3d">RC-Export3d</a> command, such as for Annotation3D in 3D geometry object properties.</p>
+<p>Any time a 3D text style is used it relies on the TextThickness property of the MText to be converted:</p>
+<ul>
+<li>
+<p>If TextThickness is greater than 0 the 3D text style is used to convert the MText to a solid,</p>
+</li>
+<li>
+<p>if TextThickness is 0 the 3D text style is not used, and the MText is not converted to a solid, but</p>
+</li>
+<li>
+<p>when exporting to IFC TextThickness is always treated as being at least 0.001.</p>
+</li>
+</ul>
+<p>When exporting MTexts to 3D RailCOMPLETE searches for saved 3D text styles. It looks in all Library Paths found under the Source tab of the <a href="050-commands.html#rc-export3d">RC-Export3d</a> settings. The saved 3D text style’s name must match the exported MText’s style name to obtain the correct style. If no matching name is found a default style is selected instead, as specified in the Source tab of the <a href="050-commands.html#rc-export3d">RC-Export3d</a> settings.</p>
+<h2 id="rc-deferrefresh">RC-DeferRefresh</h2>
+<p>Defer updates until command is turned off.</p>
+<p>Formulas, areas, properties and sections will not be updated as long as the command is active. The Object Manager will also not be updated. When the command is turned off, all deferred updates will be executed.</p>
+<h2 id="rc-detachxref">RC-DetachXRef</h2>
+<p>Detaches XRefs from RailCOMPLETE document.</p>
+<h2 id="rc-disablecontextualribbontabs">RC-DisableContextualRibbonTabs</h2>
+<p>Disables the table and XRef ribbon bar.</p>
+<h2 id="rc-display2dalignmentatelevation">RC-Display2dAlignmentAtElevation</h2>
+<p>Enables displaying of 2D alignments at a specified elevation.</p>
+<p>RailCOMPLETE alignments are represented in modelspace as 2D polylines, which are planar CAD entities. When this mode is activated, all 2D polylines are artificially raised to the selected elevation.</p>
+<p>The elevation can be set as a fixed value (see <a href="050-commands.html#rc-set2dalignmentdisplayelevation">RC-Set2dAlignmentDisplayElevation</a>) or from a point object (see <a href="050-commands.html#rc-set2dalignmentdisplayelevationfrompointobject">RC-Set2dAlignmentDisplayElevationFromPointObject</a>). The elevation can also be specified in the Property Manager when no item is selected in modelspace.</p>
+<h2 id="rc-displaybrakingcurveebicab700">RC-DisplayBrakingCurveEbicab700</h2>
+<p>Displays braking curve information, based on Ebicab700 ATC braking curve parameters.</p>
+<p>The tool uses a path from a train's initial location to a given target location but does not take into account actual gradients along that path.</p>
+<p>The braking curve computation consists of a these phases: </p>
+<ul>
+<li>
+<p>Coasting at initial speed V1 (from start-of-path to start-of-pre-indicator interval)</p>
+</li>
+<li>
+<p>Pre-indication interval (default 5s)</p>
+</li>
+<li>
+<p>Main indication interval (default 5s)</p>
+</li>
+<li>
+<p>Tone interval (default 3s)</p>
+</li>
+<li>
+<p>Brake build-up interval (a friction-free coasting interval until the brakes 'magically' produces the given deceleration r)</p>
+</li>
+<li>
+<p>Braking interval, a parabolic curve from the initial speed V1 to the final speed V2 for a given deceleration r (default 0.7 m/s2)</p>
+</li>
+</ul>
+<p>The braking distance is calculated as [(V1/3.6)^2 - (V2/3.6)^2] / (2*r).</p>
+<h2 id="rc-displayenvelope">RC-DisplayEnvelope</h2>
+<p>Displays the envelope of a network by sweeping a single axle or a two-axle rectangular body through the network.</p>
+<p>The envelope is calculated on the entire alignments (not on paths). The resulting outline is inserted on the current CAD layer.</p>
+<p>You can compute the envelope in one of the two following modes:</p>
+<ul>
+<li>
+<p>In <em>SingleAxle</em> mode, a virtual single axle is swept along all possible paths in the selected network. The virtual axle can be asymmetric. You can select to exempt an inner region.</p>
+</li>
+<li>
+<p>In <em>DoubleAxle</em> mode, a virtual rectangular body is swept along all possible paths in the selected network. The body is moved a whole body length before and after each position in the network to address the effect of inner / outer curve extensions from a moving body.</p>
+</li>
+</ul>
+<p><em>Note: If the alignments are in an XRef file, they must be selected before launching the command, because inside the command, the CAD system will select the entire XRef and not the individual axes.</em></p>
+<h2 id="rc-displaygauge">RC-DisplayGauge</h2>
+<p>Displays a loading gauge visualized in 2D, 3D or 2D+3D as a simplistic moving train.</p>
+<p>The train follows the current alignment’s track axis as you move the CAD cursor through the track network. Train motion is either manual (mouse mode) or simulated (keyboard mode).</p>
+<p>You can copy the train as an annotation into the drawing.</p>
+<p>The train comprises a user-selectable number of cars. All cars have the same length and width and are identically made up of a tail part, a part between-the-axles and a nose part. All lengths can be altered. The separation between consecutive cars is a selectable constant. It defines the length of a stiff rod which connects one car’s axle midpoint to the next car’s nearest axle midpoint. </p>
+<p>In 3D mode, a gauge profile is swept along each car’s centreline to produce a 3D shape representing the required free space around the moving train. The default gauge is the European UIC GC, ‘gabarit C’. Gauge profiles must be predefined in the DNA.</p>
+<p>Each simulated car has two axles with a total of four virtual wheels. The wheels touch the track’s two virtual rails at four points of wheel/rail contact. The virtual rails’ positions in 3D space are mathematically defined by a combination of the alignment’s geometry, vertical profile and cant, plus the applicable rail-rail distance (track gauge) and the applicable method for applying cant (*).</p>
+<p>If the alignment is skew, i.e. the cant is gradually changing, then one of the wheels will be lifted above its rail, assuming a totally stiff car body. The lifted wheel will normally be the inner-curve front wheel when the train is running into increasing cant, and the outer-curve front wheel when the train is leaving the cant situation (decreasing the margins against derailment). Both car positions are shown simultaneously in such situations, regardless of the train’s simulated running direction.</p>
+<p><em>(*) A very common cant application method is to rotate the track around the alignment axis (gradient axis, the axis in 3D space defined by geometry and vertical profile, disregarding cant) until one rail is raised with the applied cant value above the other. Subsequently, the track is translated upwards by half of the applied cant. An alternative cant application method is to rotate around the alignment axis but then omit the translation. Yet another cant application method is to keep one rail at the alignment’s elevation and then rotate the track around that rail’s inner-rail point. This method yields slightly different results than the mathematically simpler and more common rotate-around-centre-and-then-translate-upwards method.</em></p>
+<h2 id="rc-displaysighting">RC-DisplaySighting</h2>
+<p>Display sight line, region, beam or volume towards one or more objects.</p>
+<p><img alt="SightCommand_DisplaySighting" src="img/ToolTip/SightCommand_DisplaySighting.png" /></p>
+<p>The sight entity produced indicates which line, area or volume must be free from major obstacles to guarantee free sight for the locomotive driver. A signal is an example of an object that must be visible for the locomotive driver.</p>
+<p>Four distinct methods are available: sight line (1D), sight region (2D), sight beam (3D) and sight volume (3D). All methods use the target object's 'sight' property [m], defining the maximum distance from which the target object is required to be visible. The sighting algorithm stops at the specified distance from the target object. If the sighting requirement exceeds the length of the available track in front of the target object, then no sighting is presented. If there are multiple paths towards the sighting target from the specified sighting distance, then a line / region / beam / volume is created for each of these paths.</p>
+<ul>
+<li>
+<p><strong>Sight line</strong>: A 1D line from the center of the target object to the center of the track.</p>
+</li>
+<li>
+<p><strong>Sight region</strong>: A 2D region being the contour of all lines traced from left/right train window to left/right edge of target object as a virtual train moves towards the target object.</p>
+</li>
+<li>
+<p><strong>Sight beam</strong>: A 3D beam (cone) tracing a line from each of the four corners of the train window to the corresponding corners of the target object.</p>
+</li>
+<li>
+<p><strong>Sight volume</strong>: A 3D volume being the union of all locally estimated sight volumes as the virtual train moves towards the target object.</p>
+</li>
+</ul>
+<p>You can specify the color and transparency of the sighting annotation, the train window's size and its placement. If the track has cant, then the train's window is canted accordingly. Finally, for region and volume, you can specify the step size of the virtual train's movement.</p>
+<p>Sight lines and sight regions are drawn at the current 2D display elevation. Sight beams and sight volumes are drawn at their real 3D coordinates.</p>
+<h2 id="rc-editballoongroupsequence">RC-EditBalloonGroupSequence</h2>
+<p>Change the order of balloons in an existing balloon group.</p>
+<h2 id="rc-editinterlockingdatasettings">RC-EditInterlockingDataSettings</h2>
+<p>Edit settings for the selected signal box (interlocking control table).</p>
+<p>Choose to export train routes, shunting routes or both. Edit map formulas to select start and end signals for routes.</p>
+<h2 id="rc-editproperty">RC-EditProperty</h2>
+<p>Sets a property to a given value for one or more RailCOMPLETE objects.</p>
+<p>Select the object(s) and then launch the <a href="050-commands.html#rc-editproperty">RC-EditProperty</a> command. The Edit Property dialog box lets you select the property you want to modify and define its value, or its formula. Formulas may be edited directly, copied from one of the selected objects, or copied from DNA, if the property at hand has a DNA-defined formula.</p>
+<h2 id="rc-editscript">RC-EditScript</h2>
+<p>Opens the Lua script editor.</p>
+<h2 id="rc-edittable">RC-EditTable</h2>
+<p>Displays the dialog box where you can edit an existing RailCOMPLETE table.</p>
+<h2 id="rc-edittextattributes">RC-EditTextAttributes</h2>
+<p>Opens a tool for editing and manipulating the text attributes of RailCOMPLETE object(s).</p>
+<p>After choosing which objects and attributes to edit, you are presented with multiple options for editing different aspects of the selected text attributes, such as text height, text style, the oblique angle, etc. You can re-select at any time which attribute of the selected objects you want to edit.</p>
+<p>Please note that the 'Height' property is presented in its paperspace size, i.e. its real size modified by the currently selected drawing scale. E.g., Height=2.5 in scale '4:1' is the same as Height=10 in scale '1:1'.</p>
+<p>The following options are available:</p>
+<ul>
+<li>
+<p><strong>Attribute</strong>: Allows for reselection of which attribute to edit.</p>
+</li>
+<li>
+<p><strong>Height</strong>: Sets a new text height for the selected attribute(s). Accepts positive and non-zero numbers as input.</p>
+</li>
+<li>
+<p><strong>Color</strong>: Sets a new color for the selected attribute(s).</p>
+</li>
+<li>
+<p><strong>Justification</strong>: Sets a new justification for the selected attribute(s). Choose between TL (Top Left), TC (Top Center), TR (Top Right), ML (Middle Left), MC (Middle Center), MR (Middle Right), BL (Bottom Left), BC (Bottom Center) and BR (Bottom Right).</p>
+</li>
+<li>
+<p><strong>Oblique</strong>: Sets a new oblique angle for the selected attribute(s). Input is interpreted as degrees. Accepts input between -85 and 85.</p>
+</li>
+<li>
+<p><strong>Style</strong>: Sets a new text style for the selected attribute(s). When selected opens a window containing a list of all the text styles in the drawing along with a search bar. Select the desired style with a left mouse double-click or Enter.</p>
+</li>
+<li>
+<p><strong>Layer</strong>: Defines the layer in which the selected attribute(s) will be stored.</p>
+</li>
+<li>
+<p><strong>Lateraloffset</strong>: Moves the selected attribute(s) to a specified lateral offset from its alignment. The command finds the point on the alignment closest to the text attribute(s) and moves the attribute(s) to a point along this direction specified by the given offset. Negative input will place the attribute(s) on the opposite side of the alignment. If an attribute is placed on its alignment or has no alignment, the command does nothing.</p>
+</li>
+<li>
+<p><strong>Longitudinaloffset</strong>: Moves the text in the direction of increasing mileage along the object's own alignment's tangent direction.</p>
+</li>
+<li>
+<p><strong>Scale</strong>: Scales the size and relative position(s) of the selected attribute(s). Choose a scaling factor to apply to text height and relative distance. The position can either be changed according to the base attribute or the object.</p>
+</li>
+<li>
+<p><strong>Orientation</strong>: Orients the selected attribute(s). Options are Alignment, User, World and Current View, along with the option to specify the rotation point of the attributes (either its position or its alignment point). After aligning the attribute(s) to the given choice, the option to add an extra angle is given.</p>
+</li>
+<li>
+<p><strong>Move</strong>: Move the selected attribute(s) with a specified offset.</p>
+</li>
+<li>
+<p><strong>Reset</strong>: Resets the selected attribute(s) to its specification in the DNA. Choose between a 'hard' reset that includes both the properties (height, style, layer etc.) and the position(s) of the attribute(s), or a 'soft' reset that keeps the current position(s) of the attribute(s).</p>
+</li>
+<li>
+<p><strong>Match</strong>: Matches properties in attribute(s) on target object with the same name.</p>
+</li>
+<li>
+<p><strong>Exit</strong>: Exits the command and saves the changes to the database.</p>
+</li>
+</ul>
+<h2 id="rc-export2dprojections">RC-Export2dProjections</h2>
+<p>Exports 2D projections for the selected point objects to a 2D grid in modelspace, or to an external file. Each 2D projection is a collection of geometric representations contained within a specified boundary, either presented as a projected 2D drawing or the actual 3D entities.</p>
+<p>The 2D projection is parametrized by the selected point objects themselves, as well as the settings in the <a href="050-commands.html#rc-export2dprojections">RC-Export2dProjections</a> command.</p>
+<p>Use command <a href="050-commands.html#rc-export2dprojectionsusingcurrentsettings">RC-Export2dProjectionsUsingCurrentSettings</a> to trigger export using current settings.</p>
+<p>The 2D projections are presented in a customizable grid. Each cell may contain a box, a set of 3D geometries, and the corresponding 2D projection.</p>
+<ul>
+<li>
+<p>The box is used to capture nearby source objects, which are included to enrich the context when expressing the selected object's 2D projection.</p>
+</li>
+<li>
+<p>The 3D source geometries are expressed from the selected point objects and its captured context. Only their parts being inside the box are shown.</p>
+</li>
+<li>
+<p>The 2D projection is produced by projecting the 3D source geometries onto the primary face of the box.</p>
+</li>
+</ul>
+<p>Output may be directed to the current drawing or to an external file. Settings such as layers, colours and annotations are available.</p>
+<h2 id="rc-export2dprojectionsusingcurrentsettings">RC-Export2dProjectionsUsingCurrentSettings</h2>
+<p>Exports 2D projections of selected objects using the previously saved settings in the <a href="050-commands.html#rc-export2dprojections">RC-Export2dProjections</a> command.</p>
+<h2 id="rc-export3d">RC-Export3d</h2>
+<p>Exports the 3D geometries of the selected objects to the modelspace, to an external DWG file, or to IFC.</p>
+<p>Use the RC-Create3DTextStyle command to export using the current settings.</p>
+<p>3D geometries are retrieved from one or several folders containing 3D representations of objects.</p>
+<p>3D geometry complexity may be reduced using the Level Of Detail (LOD) algorithm.</p>
+<p>Parameters such as layer, color, transparency, annotations, block name and block-in-block structure may be controlled using each individual object's 3D properties in combination with the <a href="050-commands.html#rc-export3d">RC-Export3d</a> command's settings.</p>
+<p>3D geometries may contain a polyline stub and a circle, representing a default part of the object's pole, useful for signs and boards. Automatic pole routing is available as either horizontal end or vertical end.</p>
+<p>Alignments may be expressed in 3D as a centerline and/or as a succession of 3D geometries representing a repeated object (such as a cable duct element or a sleeper with 60 cm of rails). Object annotations and alignment mileage annotations are available.</p>
+<p>The Level Of Detail (LOD) algorithm considers the object's volume and either ignores it (small volumes) or replaces it by a box of similar volume.</p>
+<p>See <a href="060-export3d.html">3D Export</a> for more information.</p>
+<h2 id="rc-export3dusingcurrentsettings">RC-Export3dUsingCurrentSettings</h2>
+<p>Exports 3D geometries of selected objects using the previously saved settings in the <a href="050-commands.html#rc-export3d">RC-Export3d</a> command.</p>
+<h2 id="rc-exportalignmentstolandxml">RC-ExportAlignmentsToLandxml</h2>
+<p>Exports RailCOMPLETE document to LandXML format.</p>
+<h2 id="rc-exportreferencealignmentdefinitionstoxml">RC-ExportReferenceAlignmentDefinitionsToXml</h2>
+<p>Exports reference alignment definitions from the current CAD document.</p>
+<h2 id="rc-exporttabletoexcel">RC-ExportTableToExcel</h2>
+<p>Exports selected tables to Excel.</p>
+<h2 id="rc-groupballoons">RC-GroupBalloons</h2>
+<p>Combine existing ballons into a group.</p>
+<p>Objects that belong to a balloon group will move together when the head of the balloon group is moved.</p>
+<h2 id="rc-help">RC-Help</h2>
+<p>Opens a web browser with RailCOMPLETE help resources.</p>
+<p>Pressing F1 when the mouse pointer hovers over an icon also opens the help window.</p>
+<h2 id="rc-importalignmentsfromlandxml">RC-ImportAlignmentsFromLandxml</h2>
+<p>Imports alignments from LandXML file(s) to the current document.</p>
+<p>You can import each alignment as a new object or update an existing one.</p>
+<h2 id="rc-importpolylinesfromdwg">RC-ImportPolylinesFromDwg</h2>
+<p>Imports polylines from a DWG file to the current document.</p>
+<p>You can import polylines of type Polyline, Polyline2D and Polyline3D as well as Line or Arc entities.</p>
+<p>You can filter the source objects with a (partial) layer name. The polylines may thereafter be converted to alignments using the command <a href="050-commands.html#rc-insertalignment">RC-InsertAlignment</a>.</p>
+<h2 id="rc-importreferencealignmentdefinitionsfromxml">RC-ImportReferenceAlignmentDefinitionsFromXml</h2>
+<p>Imports reference alignment definitions from an XML file.</p>
+<h2 id="rc-insert3dpreview">RC-Insert3DPreview</h2>
+<p>Generates 3D for selected objects and inserts the result in the current drawing. Does not depend on the 3D settings, except for the 3D source folders.</p>
+<p>In particular, this command mimics the behavior of the '<a href="050-commands.html#rc-show3dpreview">RC-Show3dPreview</a>' command, except that created 3D is inserted into model space instead of being shown as temporary transients.</p>
+<p>The following export settings are used and cannot be changed:</p>
+<ul>
+<li>
+<p>3D library folders are taken from the '<a href="050-commands.html#rc-export3d">RC-Export3d</a>' settings.</p>
+</li>
+<li>
+<p>Defpoints are enabled.</p>
+</li>
+<li>
+<p>Logging is disabled.</p>
+</li>
+<li>
+<p>The output is all sent to a layer specified in the drawing settings, found with the '<a href="050-commands.html#rc-settings">RC-Settings</a>' command.</p>
+</li>
+</ul>
+<p>If you want to change this behavior, use the '<a href="050-commands.html#rc-export3d">RC-Export3d</a>' or '<a href="050-commands.html#rc-export3dusingcurrentsettings">RC-Export3dUsingCurrentSettings</a>' command instead.</p>
+<h2 id="rc-insertalignment">RC-InsertAlignment</h2>
+<p>Inserts an alignment by drawing segments, by converting existing 2D or 3D polylines, or by offsetting an existing alignment.</p>
+<p>Select first the type of alignment in the dropdown menu (or in the command line). Next, start the drawing mode by selecting the starting point for the alignment, or choose Polyline or Offset.</p>
+<p><em>Note: If the pickfirst selection set already contains polylines, the Polyline mode starts by default.</em></p>
+<p>An alignment always contains horizontal geometry data, and optionally data for vertical profile and cant (superelevation). Use one of the following options to create the horizontal geometry of the new alignment:</p>
+<ul>
+<li>
+<p>Drawing mode: draw the alignment directly in the modelspace. You can lock parameters and specify segment type, directions, radiuses, differentiability and more. Left-click to commit the segment that is currently being drawn. Press Enter to add the current alignment to the database. Press Esc to cancel: the alignment that is currently being drawn will not be added to the database.</p>
+</li>
+<li>
+<p>Polyline mode: select an existing 2D polyline and convert it into a RailCOMPLETE alignment.</p>
+<ul>
+<li>
+<p>If you select a 3D polyline, its vertical component defines the vertical profile.</p>
+</li>
+<li>
+<p>If the selection contains numerous polylines (&gt;4), you can choose to enter name for each alignment separately, or to enter a name for the first alignment and let RailCOMPLETE increment the name for each successive polyline in the selection.</p>
+</li>
+</ul>
+</li>
+<li>
+<p>Offset mode: define the horizontal and/or vertical offset values.</p>
+</li>
+<li>
+<p>Replace mode: deletes an existing alignment and creates a new alignment object with the same geometry. Some properties of the existing alignment are preserved, see 'Settings' under 'Replace' for details.</p>
+</li>
+</ul>
+<p>After the alignment is created, you can graphically edit its horizontal geometry by moving the grip points of the 2D polyline. To edit the vertical profile or the cant data, use the Alignment Manager (<a href="050-commands.html#rc-managealignments">RC-ManageAlignments</a>).</p>
+<h2 id="rc-insertarea">RC-InsertArea</h2>
+<p>Inserts a RailCOMPLETE area by specifying points or by using an existing closed 2D or 3D polyline.</p>
+<p><img alt="CreateArea_CreateAreaCommand" src="img/ToolTip/CreateArea_CreateAreaCommand.png" /></p>
+<p>Select the area type and click in the modelspace to define the area boundary. You can enter a value for the property <code>code</code> after the area boundary is defined.</p>
+<p>Use this option to insert for instance a working area or an Operational Control Point area.</p>
+<p>A RailCOMPLETE area is a closed 2D polyline projected onto the XY plane. A RailCOMPLETE object whose insertion point lies in the area belongs to the area. An object may belong to multiple areas.</p>
+<p>An area keeps track of the objects it contains, and is automatically updated when an object is moved into or out of the area.</p>
+<h2 id="rc-insertpointobject">RC-InsertPointObject</h2>
+<p>Inserts a new RailCOMPLETE point object.</p>
+<p>Select the type of object and position it in modelspace. The new object tries to attach itself to a nearby alignment, most often with a certain snap distance. Snapping can be toggled during insertion, and may also be overridden by moving the object after insertion.</p>
+<p><strong>1. Position of the object</strong></p>
+<p>The position of the object is defined as followed:</p>
+<ul>
+<li>
+<p><strong>Own alignment and position</strong>: The alignment that a point object has attached itself to is called the object’s <em>own alignment</em>. The object’s mileage is defined at insertion by its own alignment’s name and the resulting own alignment distance along, measured at a straight angle from own alignment to the object’s insertion point in the XY plane. There is a unique correspondence between the object’s mileage and its perpendicular distance from own alignment, and the object’s position in the XY-plane. The object’s Z-coordinate is made up of the object’s elevation relative to the local alignment elevation, and the own alignment’s actual Z-coordinate – i.e., the alignment’s elevation above mean sea level – at that mileage.</p>
+</li>
+<li>
+<p><strong>Reference alignment</strong>: Nearby alignments often belong to a named alignment group, constituting a railway line. One of these alignments is usually nominated as the <em>reference alignment</em> for the line as a whole. Each alignment knows its reference alignment’s name at every position. Thus, a point object has an alternative mileage definition, expressed as the unique reference alignment name and the reference alignment absolute position (rtap), measured at a straight angle from reference alignment to the object’s insertion point in the XY plane.</p>
+</li>
+<li>
+<p><strong>Coordinate system</strong>: The end user of the entire model, at construction time, interprets XY positions as points according to a certain mapping of the earth, for instance UTM-32. This mapping must be the same for all the drawings constituting the model. Likewise, the Z-coordinate is interpreted as an elevation according to a particular model of the earth’s surface.</p>
+</li>
+<li>
+<p><strong>Direction</strong>: In addition to a definite XYZ position in 3-dimensional space, a point object also has a rotation in the XY-plane. The Z-axis for a point object is always upright. </p>
+<ul>
+<li>
+<p>Most point objects will automatically orient themselves along their own alignment.</p>
+</li>
+<li>
+<p>Some objects, for instance optical signals, must be oriented up or down along the alignment. The direction of intended use for a point object can be changed during the insertion process, or later.</p>
+</li>
+<li>
+<p>Other point objects, such as cabinets, have four natural orientations:</p>
+<ul>
+<li>
+<p><em>up</em>: a driver running in the alignment’s ‘up’ direction will see the front door of the cabinet.</p>
+</li>
+<li>
+<p><em>down</em>: the driver will see the cabinet’s rear side. </p>
+</li>
+<li>
+<p><em>both</em> : train drivers in both running directions will see the cabinet door, opening towards the alignment. </p>
+</li>
+<li>
+<p><em>none</em>: no driver will see the cabinet’s door since it opens away from the alignment.</p>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>
+<p><strong>Position of graphics in drawing vs. the object's insertion point</strong>: The 2D symbol of a point object may be offset from its insertion point in the XY-plane using the square grip (if so enabled in the DNA). This helps tidying up a 2D drawing cluttered with overlapping symbols. A transient dashed line appears when you move the object around to indicate its so-called display position.</p>
+</li>
+</ul>
+<p><strong>2. Properties of the object</strong></p>
+<p>The property data fields of an object are populated with initial values as defined in the DNA file. Data values can alternatively be defined with a script. Their definite values will then result from a runtime evaluation and will be based on the object’s position and its relations to other objects. Such values defined by formulas are refreshed when the object is created, moved or otherwise changed, or when its related objects change. Remember though to explicitly refresh the objects before exporting them to 3D, using them in a table, etc.</p>
+<p>Many point objects are shown in 2D drawings with text attributes. These text attributes are defined in the DNA. Text attribute contents are driven by a dedicated data item found in the base class for the point object in question, or a custom property, as detailed in the DNA. You can modify or reset the text attributes, for instance rotate texts along a alignment or along a paper drawing’s borders (see the command <a href="050-commands.html#rc-edittextattributes">RC-EditTextAttributes</a>).</p>
+<p>Use the Property Manager to show and/or modify the object’s position values and its properties (see the command <a href="050-commands.html#rc-manageproperties">RC-ManageProperties</a>).</p>
+<p><strong>3. Attaching a point object to another point object</strong></p>
+<p>A point object may be attached to another point object. For instance, a signal board can be attached to a nearby foundation as part of the point object insertion dialog. When selecting an object with an attachment, a transient arrow will indicate the direction of attachment. Such an object may inherit its real position from the parent object. In our example, the signal board will by default inherit its real XYZ position from the foundation, to whom it is attached . This allows for a board's tail to be drawn from the board’s 2D symbol to its foundation, making it graphically clear which running direction and side of alignment the board is meant for. Poles and signs are likewise treated. Boards can be stacked on the same pole by attaching the next board to the previous board. In such a case, the attachment tail is suppressed for the stacked board, and its real XYZ position is derived from the foundation at the bottom of the stack. This position inheritance can be modified at any time for any point object.</p>
+<p><strong>4. Visualizing objects in 3D</strong></p>
+<p>Most point objects have an associated 3D geometry that can be generated using the <a href="050-commands.html#rc-export3d">RC-Export3d</a> command. Using the Properties or Object Manager tools, the 3D geometry can be offset from the insertion point of the object with the 3D Offsets X/Y/Z properties, as well as rotated in space with the 3D Pitch/Roll/Yaw properties. All these properties are accessible in the Property Manager and in the Object Manager. This allows for instance a wayside board to be drawn vertically above its foundation, or sideways towards the alignment when being wall-mounted in a tunnel. To allow for quick 3D modeling of poles and masts, every point object can use horizontal or vertical pole routing at 3D export time. For more detail refer to the command <a href="050-commands.html#rc-export3d">RC-Export3d</a>.</p>
+<h2 id="rc-insertpredefinedtable">RC-InsertPredefinedTable</h2>
+<p>Inserts a predefined RailCOMPLETE table.</p>
+<p>Select the type and variant, and position the table in modelspace.</p>
+<p>Once the table is created, you can edit it and export it to Excel with the command <a href="050-commands.html#rc-edittable">RC-EditTable</a>.</p>
+<h2 id="rc-inserttable">RC-InsertTable</h2>
+<p>Inserts a RailCOMPLETE table.</p>
+<p>The Insert Table window dialog box where you can insert a variety of customized tables by selecting objects and parameters. You can also use Lua expressions to define table values.</p>
+<h2 id="rc-joinalignments">RC-JoinAlignments</h2>
+<p>Joins two or more alignments of the same RC Type.</p>
+<p>The old alignments are erased, and all alignment data and attached objects are transfered to the new alignment.</p>
+<p>The first selected alignment transfers its ID and its properties to the new alignment. The remaining alignments' properties and ID's are deleted.</p>
+<h2 id="rc-loadribbon">RC-LoadRibbon</h2>
+<p>Starts RailCOMPLETE ribbon menu.</p>
+<p>Use this command if the RailCOMPLETE ribbon menu does not show after AutoCAD start-up.</p>
+<h2 id="rc-loadsymbollibraryfromdwg">RC-LoadSymbolLibraryFromDwg</h2>
+<p>Deletes all 2D symbols from the current drawing and loads new symbols from the selected DWG file.</p>
+<p>2D symbols act as visual placeholders in your drawing, representing point objects. A 2D symbol library is a file with CAD system blocks. The installation of RailCOMPLETE contains a default library for each represented railway administration.</p>
+<p>Warning: Make a backup of your drawing before applying this command.</p>
+<p>Loading a different symbol library modifies the appearance of both existing and new objects. The symbols’ CAD system block names must correspond to the names used in the DNA for each variant within an object type declaration. Loading a symbol library which is incompatible to the drawing’s current DNA gives unexpected results.</p>
+<p><em>Note: Updating the symbol library also resets the list of drawings to ignore in 3D export when 'Ignore Missing Geometries / Profiles' is turned on.</em></p>
+<p><strong>1. Managing the CAD layers</strong></p>
+<p>2D symbols usually contain several graphical components distributed on several CAD layers. At the creation of an object, a symbol will be included in a unique anonymous block of the CAD system and assigned to a specific layer, along with possible CAD system text attributes declared in the DNA for the relevant object type. The principal graphical components of a 2D symbol are always drawn on CAD layer 0. Secondary graphical components may reside on other CAD layers, called 'component layers'. Component layers can be de/activated in the CAD system’s layer manager. In many cases the DNA using the 2D symbol library has declaration of such (groups of) component layers, which can be activated alone or as a layer group using the command <a href="050-commands.html#rc-showlayergroups">RC-ShowLayerGroups</a>. The effect is to toggle on/off the desired sub-items of the 2D symbols. For instance, the component characteristics of a switch symbol may be 'track appearance”, 'signaling appearance' or 'catenary appearance'.</p>
+<p><strong>2. Colors</strong></p>
+<p>The coloring of symbols is manipulated by several tools within RailCOMPLETE.</p>
+<p><strong>3. 2D symbol parts</strong></p>
+<p>The anonymous block which is instantiated for a given object type and variant at the object’s creation may contain several other graphic components along with the basic 2D symbol. These drawing elements are also CAD system blocks, to be found in the symbol library file. A typical example is an 'insertion point' showing where the local '0,0' block insertion point is.</p>
+<p><strong>4. Changing 2D symbol when variant is changed</strong></p>
+<p>Changing an object’s variant usually results in a change of 2D symbol, e.g. when changing a 3-light main signal into a 4-light signal. The available object types variants within each object type are declared in the DNA. Each object type, and often each individual variant for that object type, will appear in modelspace as a dedicated 2D symbol.</p>
+<p><strong>5. Text attributes in 2D symbols</strong></p>
+<p>For every object type and variant, CAD system text attributes can be defined in the DNA. Each text attribute is linked by its name to one of the object’s generic or custom properties. The current value of that property is displayed as text in modelspace along with the 2D symbol and is updated on the screen whenever there is a change in that property’s value. The default position for each text attribute within the object’s anonymous block is declared in the DNA. Several methods are available for modifying the position, orientation, and appearance of text attributes after the object has been created, see the command <a href="050-commands.html#rc-edittextattributes">RC-EditTextAttributes</a>.</p>
+<h2 id="rc-managealignments">RC-ManageAlignments</h2>
+<p>Activates/desactivates the Alignment Manager.</p>
+<p>Alignments are curved-line objects in 3D space, such as tracks, catenary wires, cables, cable ducts, roads, hand-rails, etc.</p>
+<p>An alignment must have a geometrical description in the XY plane. Positions along the alignment are measured from start to end in the XY plane. An alignment may also have a profile description (vertical), defining the Z coordinate for points on the alignment (otherwise it will implicitly be zero). Additionally, alignments may have cant information, defining a rotation at every position.</p>
+<p>The Alignment Manager lets you view and to some extent also add, delete or modify information relative to alignments.</p>
+<h2 id="rc-managedrawinglibrary">RC-ManageDrawingLibrary</h2>
+<p>Manages layer preferences.</p>
+<p>The tool scans selected drawings for layers, and list the layers with their properties. The layers can then be grouped and assigned properties like color, transparency, line type, etc.</p>
+<p>Use the Manage Drawing Library to assign source and target layer for 3D export.</p>
+<h2 id="rc-managelicense">RC-ManageLicense</h2>
+<p>Opens the RailCOMPLETE license manager.</p>
+<p>License information is shown. You can also enter a new license code or a order new license.</p>
+<h2 id="rc-manageobjects">RC-ManageObjects</h2>
+<p>Activates/desactivates the Object Manager.</p>
+<p>The Object Manager is organized as a spreadsheet, presenting objects in rows, and their properties in columns. You can edit, copy-paste-autofill, search and replace values, you can filter and sort rows, you can add, hide or reorganize columns. You can target objects in the Object Manager and zoom in on them in the drawing, or you can select objects in the drawing and open the Object Manager with focus on that object.</p>
+<p>The contents of the Object Manager can be exported to Excel, or inserted as a CAD system table into the drawing, for further refinement there.</p>
+<p><strong>1. Interaction with modelspace</strong></p>
+<p>You can easily switch between your CAD system’s model space and the Object Manager. The model space, the Object Manager and the Properties Manager are always synchronized: you can select objects in the model space and act upon them in the Object manager, and vice versa, or you can select a group of objects in the Object Manager or in the model space and then act on them as a group in the Properties Manager. You can set up filtering and sorting and then single-step through the resulting objects one by one in the Object Manager, while you zoom to the current object in model space - useful for a quick assessment of your objects.</p>
+<p><strong>2. Browsing Objects</strong></p>
+<p>You can limit globally the set of objects shown in the Object Manager to the ones selected in the model space or belonging to a certain area. By default, objects belonging to layers that are frozen or off are not shown. You can also select to ignore objects in XRefs. The object category browser groups the objects based on the nomenclature defined in your railway administration’s DNA. You can turn on/off whole (sub)groups of objects.</p>
+<p><strong>3. Selection and Marking</strong></p>
+<p>A <em>selected</em> object means an object that is part of the CAD system’s current selection set, normally being highlighted with grips in model space. A <em>marked</em> object means an object with one or more gray-marked cells in the Object Manager window. Marked cells can be acted on in the Object Manager, but the CAD system has no notion of marked objects.</p>
+<p><strong>4. Column Selection and Organization</strong></p>
+<p>You can easily organize the Object Manager as you prefer: right-click in a column header to add and delete (or un/hide) columns, and drag columns sideways to change the order.</p>
+<p><strong>5. Column Filters</strong></p>
+<p>Individual filters can be defined per column. Here you can use wildcards (click Help to see the syntax). You can also invert the result of the filtering, that is show the rows that do NOT satisfy the column filters.</p>
+<p><img alt="ObjectPaletteCommand_PaletteCommand" src="img/CommandDescriptions/ObjectPaletteCommand_PaletteCommand_1.png" /></p>
+<p><strong>6. Modifying Cell Values</strong></p>
+<p>You can modify cell values through direct data entry, or through the Search and Replace tool, or the Auto Fill tool. Double-click in a cell or press F2 to start editing. Cell values can be modified even if the CAD system layer that the object resides on is frozen or turned off, i.e. even if you can’t see the object in the CAD system model space window. CAD system layer properties can be modified from the Object Manager. Non-editable cells are permanently grayed out, either because the objects containing these cells reside in an XRef, or because the object’s CAD system layer is locked against editing.</p>
+<p><strong>7. Formulas</strong></p>
+<p>Cell values may be driven by formulas. Double-click in a cell (or press F2 or F3) to start editing the cell: a formula editor symbol appears to the right of the cell. Clicking on this symbol starts the usual Lua formula editor tool (Refer to the Lua help page for more information). Define your formula, then save and close the editor to return to the Object Manager. Alternatively, enter your formula directly in the cell, starting with a sign ‘=’, and press Enter once done.</p>
+<p><strong>8. Protecting Formulas</strong></p>
+<p>When saving and closing the Lua editor, or when pressing Enter after in-cell editing, you will see that a formula symbol appears to the left in the cell. This indicates that there is a formula behind the displayed cell value. Trying to type in a new cell value directly will no longer work, to protect your formula from being overwritten by accident. The other tools accessing the properties (Manage Properties and Edit Properties) will also be blocked from accidentally overwriting a formula. To edit the formula again, simply open the Lua editor or edit the formula directly in the cell.</p>
+<p><strong>9. Removing Formulas</strong></p>
+<p>To remove a formula, re-enter cell edit mode and replace the Lua formula with an entirely blank formula. Alternatively, right-click and select 'Replace formula with cell value”. The previously shown value – the result of the formula – will now replace the formula. If the formula previously had an error or evaluated to a blank cell, then the cell value will now be empty.</p>
+<p><strong>10. Drawing Attention to a Value with Warnings and Checkmarks</strong></p>
+<p>In case of an error in a formula, the Lua editor warns you and helps finding the error. Formulas with Lua syntax errors show up in the Object Manager cell as blank, with a warning sign along with the formula symbol.</p>
+<p><em>Tip: To make a formula return a value x and at the same time show the warning triangle, use this Lua statement: <code>return x, _warning</code> (or <code>return _warning,x</code>). You may return the following attention symbols: <code>_unfinished</code> (a question mark on a light blue disc), <code>_error</code> (a white 'X' on a red disc), <code>_warning</code> (a yellow warning triangle), or <code>_ok</code> (a check mark on a green disc). There is also a function <code>_info("a text")</code> which will display that text together with a blue symbol featuring an 'i' inside a circle.</em></p>
+<p><strong>11. Export Object Data to Excel</strong></p>
+<p>The Object Manager allows for easy export to Excel. Once you have set up your column selection, object filters, and sorting, click on the Excel export button: the current view is exported to a new spreadsheet including column titles and respecting the sorting order.</p>
+<p><strong>12. Create Tables</strong></p>
+<p>The Object Manager is also the starting tool for producing high-quality tables. Set up columns and rows as for the Excel export, then click on the RailCOMPLETE Table button. The Table Manager opens, where you can further refine the table definition, save it, and finally insert the table into model space. Export from this refined table definition is then available from the Table Manager.</p>
+<h2 id="rc-manageproject">RC-ManageProject</h2>
+<p>Manage your RailCOMPLETE project.</p>
+<p>At first use, the command lets you select a railway administration and a particular Definition of Network Assets (DNA) for that administration. RailCOMPLETE injects that DNA into your drawing. The drawing then becomes a RailCOMPLETE document.</p>
+<p>At subsequent uses, you are offered a dashboard containing project information accessible in and from the active RailCOMPLETE document.</p>
+<p>The command's icon initially displays a rally flag to denote the start of a new RailCOMPLETE document. Thereafter, the icon changes into the chosen railway administration's logo.</p>
+<h2 id="rc-manageproperties">RC-ManageProperties</h2>
+<p>Activates/deactivates the Properties Manager.</p>
+<p>All the properties of the currently selected objects are displayed with their name and value. The formula symbol indicates that the property’s value results from an underlying formula.</p>
+<p>Properties are grouped in categories that you can expand and collapse. You can also modify the properties' value with this tool.</p>
+<p>When multiple objects are selected that have different values for a given property, the Property manager displays <em>VARIES</em>. Similarly, when multiple objects use a different formula for a given property, the formula symbol changes to an asterisk *, even when all the formulas give the same value.</p>
+<p>See also the command <a href="050-commands.html#rc-editproperty">RC-EditProperty</a>.</p>
+<h2 id="rc-managepropertysetdefinitions">RC-ManagePropertySetDefinitions</h2>
+<p>Manage property set definitions defined for this project. Property set definitions may be associated with object types, which means that objects may only use some of the defined property sets.</p>
+<p>The functionality lets the user create new property set definitions or edit existing. For example, the user may add new properties to already existing property set definitions or change the names of existing properties. This will also change property sets that are already used by objects, without changing the value of the properties.</p>
+<p>Property set definitions may be shared between documents if “Distribute” is checked for the property set definition. If the document containing this property set is then Xref’ed into another document, the property set definition may also be used by the document containing the Xref. Property set definitions may also contain user defined enumerations. The enumerations may be edited or extended even if they are already in use by objects.</p>
+<h2 id="rc-managestagesusinglayernames">RC-ManageStagesUsingLayerNames</h2>
+<p>Turns the CAD system layers on and off in order to display stage-dependent drawing details for objects that reside on the affected layers.</p>
+<p>Objects may be RailCOMPLETE objects or any type of CAD object (circle, line, block, leader, text, XRef etc.).</p>
+<p>Specify the stage pattern, optionally with a user-defined prefix, entering/leaving prefix and suffix patterns, the number of digits used for denoting main- and sub-stage numbers, as well as a user-defined main/sub-stage separator.</p>
+<p>For instance, the pattern 'MyPrefix', '2', '.', '2', '-', 'MySuffix' refers to all layers whose names contain 'MyPrefix##.##-##.##MySuffix', where # denotes any single digit 0-9.</p>
+<h2 id="rc-matchdynamicproperties">RC-MatchDynamicProperties</h2>
+<p>Matches the dynamic properties of the target object(s) to the dynamic properties of the source object.</p>
+<p>At first, select the source object holding the correct set of dynamic properties. Then select the target object(s) that will get their dynamic properties matched to those of the source object.</p>
+<p>Use the command's Settings menu to choose which dynamic property types to match and how to match them. You can choose to either Replace, Prepend or Append dynamic properties in the target object(s) using the source object's dynamic properties as the template.</p>
+<p>While selecting target object(s), use the "sImilar" option to extend the target object selection to all objects being similar to the ones already selected.</p>
+<p>A <strong>Dynamic Property</strong> is a set of properties that you can add to an object by clicking the "Add" button in Manage Properties (the plus sign). There are two possible types of Dynamic Properties: «Representation3D» which governs the appearance in 3D associated with the object, and «Projection2DCollection» which is a two-dimensional virtual picture of the object from a given angle.</p>
+<p><strong>Examples</strong></p>
+<p>1) Let the target object have a Dynamic Property of Type «Representation3D» and Subtype «IteratedGeometry3D» (Property name: IteratedGeometry3D_0)</p>
+<p>2) Let the source object have a Dynamic Property of Type «Representation3D» and Subtype «SweptGeometry3D» (Property name: SweptGeometry3D_0)</p>
+<p>3) If you use the <strong>Prepend</strong> option, then the Dynamic Properties of the source object are added <strong>in front</strong> of the already existing Dynamic Properties in the target object (at lower indexes):</p>
+<pre><code>Target object will end up with properties:  SweptGeometry3D_0 and IteratedGeometry3D_1
+</code></pre>
+<p>4) If you use the <strong>Append</strong> option, then the Dynamic Properties from the source object are added <strong>after</strong> of the already existing Dynamic Properties in the target object (at higher indexes):</p>
+<pre><code>Target object will end up with properties:  IteratedGeometry3D_0 and SweptGeometry3D_1
+</code></pre>
+<p>5) If you use the <strong>Replace</strong> option, then the existing Dynamic Properties in the target object will be removed before the Dynamic Properties of the source object are added:</p>
+<pre><code>Target object will end up with property:    SweptGeometry3D_0
+</code></pre>
+<h2 id="rc-matchformulas">RC-MatchFormulas</h2>
+<p>Matches formulas in the target object with the formulas in the source object.</p>
+<p>First select the source object holding the correct formula(s). Then select the target object(s) whose formula(s) will be changed. Use the 'Settings' option to select how differences in formulas between source and target(s) will be treated.</p>
+<p>Use the 'sImilar' option when selecting the target object(s) to select all objects being similar to the targets that have already been selected.</p>
+<p><strong>Source object</strong></p>
+<p>An object being selected before or after starting the command. This object's Lua formulas are the ones that will be copied from.</p>
+<p><strong>Target object(s)</strong></p>
+<p>The object(s) selected in a second step, that will have its / their formulas altered.</p>
+<p><strong>Remove unmatched formulas</strong></p>
+<ul>
+<li>If "Yes" is selected, formulas on properties will be removed from the target objects if the source object does not have a formula on that property.</li>
+</ul>
+<p><strong>Overwrite matched formulas</strong></p>
+<ul>
+<li>If "Yes" is selected, formulas on properties in the target object will be replaced by the formula on the same property in the source object. If "No" is selected, the target objects will keep their original formulas.</li>
+</ul>
+<h2 id="rc-matchposition">RC-MatchPosition</h2>
+<p>Matches the position of one or more target objects to that of a source object.</p>
+<p>The target object positions will be derived from the source object’s own alignment / reference alignment / XY coordinate / XYZ coordinate properties.</p>
+<h2 id="rc-moveselectionalongpath">RC-MoveSelectionAlongPath</h2>
+<p>Moves the selection of objects along a path, based on input parameters.</p>
+<p>Items can be moved along (reference) alignment.</p>
+<h2 id="rc-movetextattributes">RC-MoveTextAttributes</h2>
+<p>Moves all the text attributes of the selected objects.</p>
+<p>Select two points to define the displacement vector. A transient jig is shown throughout to illustrate the changes in attribute positions. If no selection set was active, you can make a selection or choose the option 'Select all'.</p>
+<h2 id="rc-offsetalignment">RC-OffsetAlignment</h2>
+<p>Creates or modifies alignment by curve offset.</p>
+<p>Define an offset distance and a direction from the selected alignment. You can keep the original alignment or erase it. The resulting alignment has the same type as the original alignment.</p>
+<p>As input the command accepts an alignment, a new drawn path or an existing selected path.</p>
+<p>First, offset command parameters are given:</p>
+<ul>
+<li>
+<p>Apply: finish parameter selection and proceed to picking the through point or the offset direction.</p>
+</li>
+<li>
+<p>Offset: offset distance. Must be a positive number, or the 'Through' value.</p>
+</li>
+<li>
+<p>Z offset: vertical offset distance. A positive numbers indicates upwards offset, a negative number indicates downwards offset.</p>
+</li>
+<li>
+<p>Erase: if set to yes, the original alignment is erased after the new alignment has been created.</p>
+</li>
+<li>
+<p>Layer: 'Source' uses the layer of the original alignment, while 'Current' uses the current insertion layer of the drawing.</p>
+</li>
+</ul>
+<p>Next, the through point or the offset direction is chosen by picking a point. A new alignment is created.</p>
+<p>The type of the resulting alignment is the same as the original alignment. To create an alignment with another type, use the command <a href="050-commands.html#rc-insertalignment">RC-InsertAlignment</a> with the option 'Offset'.</p>
+<p><em>Note: This command is similar to the AutoCAD OFFSET command.</em></p>
+<h2 id="rc-offsetprofile">RC-OffsetProfile</h2>
+<p>Modifies linear event profiles of an alignment by offsetting them from another alignment. Vertical and cant profiles are examples of linear event profiles.</p>
+<p>First select the source, followed by the target - these can be alignments or paths, new or existing.</p>
+<p>See settings for detailed behavior. They can be accessed by running the command, hitting the down arrow key, and selecting 'Settings'.</p>
+<p>This command works best in cases where source and target have similar horizontal geometries, but do not overlap.</p>
+<p><strong>Profiles</strong></p>
+<p>This command is capable of offsetting the following linear event profiles:</p>
+<ul>
+<li>
+<p>Vertical profile</p>
+</li>
+<li>
+<p>Cant profile</p>
+</li>
+<li>
+<p>Speed profile</p>
+</li>
+</ul>
+<p><strong>What the offset does</strong></p>
+<p>Here is a picture of a typical use case:</p>
+<p><img alt="OffsetProfileCommand_AssistOffsetProfileCommand" src="img/CommandDescriptions/OffsetProfileCommand_AssistOffsetProfileCommand.png" /></p>
+<p>The process starts with both a source alignment and a target alignment. The source alignment has linear events of the relevant type, PVIs in the above example. The target alignment can have them or not, they'll be overwritten in the relevant area either way.</p>
+<p>Next, each linear event is transferred/offset from the source alignment to the target alignment. Exactly how this is done depends on the linear event type and projection method. The default case is that each linear event is offset orthogonally from the source alignment, and transferred to the point on the target alignment that intersects the orthogonal line.</p>
+<p><strong>Further details</strong></p>
+<p>See the command setting menu mentioned above for more details on the following:</p>
+<ul>
+<li>
+<p>Sanity Check: There is a rule of thumb sanity check that checks if the offset profiles are roughly similar to what you would expect.</p>
+</li>
+<li>
+<p>Sampling Mode: An alternative way of offsetting that uses sampled points instead of the linear events themselves.</p>
+</li>
+<li>
+<p>Advanced: Various settings that can be used to fine-tune the offsetting process. In most cases these should be left at their default values.</p>
+</li>
+</ul>
+<h2 id="rc-opengeneraltutorialsfolder">RC-OpenGeneralTutorialsFolder</h2>
+<p>Opens the general tutorials folder in file explorer.</p>
+<p>General tutorials are not customized to a specific railway administration.</p>
+<h2 id="rc-openlogfile">RC-OpenLogFile</h2>
+<p>Opens the RailCOMPLETE log file.</p>
+<p>The RailCOMPLETE log file is located in your %TEMP% folder and contains information gathered from RailCOMPLETE startup, license validation, error events and RailCOMPLETE command usage. This log file is not transmitted to the Manufacturer unless you, the End User, decide to do so, via file sharing, screen sharing or any other media. An End User may be asked to share such information when contacting the Manufacturer's support or licensing department.</p>
+<h2 id="rc-opennationaltutorialsfolder">RC-OpenNationalTutorialsFolder</h2>
+<p>Opens the custom tutorials folder in file explorer.</p>
+<p>Custom tutorials are specific to your railway administration.</p>
+<h2 id="rc-openxref">RC-OpenXRef</h2>
+<p>Opens the XRef'ed RailCOMPLETE document in a new window.</p>
+<h2 id="rc-quantizeposition">RC-QuantizePosition</h2>
+<p>Quantizes the selected object’s absolute position, rounding either the mileage value or the reference mileage value to the nearest multiple of the selected quantization step size.</p>
+<p>Specify first the object’s alignment or its reference alignment mileage to be quantized. Select then the quantization value 'Q' (default is 1). A measurement value 'V' will be mapped into: floor((V + Q/2)/Q)*Q.</p>
+<p>For instance, V=16.221 and Q=2.5 maps to 15.0. V=16.267 and Q=2.5 maps to 17.5.</p>
+<h2 id="rc-queryobject">RC-QueryObject</h2>
+<p>Opens a Query Object window where you can access all drawing information linked directly or indirectly to the selected object.</p>
+<p>The Query tool uses Lua to access information from the drawing with the currently selected object as a starting point. For instance, if the selected object is a turnout with '512' as @code property value, typing code will show 512. Note that Lua is generally case-sensitive.</p>
+<h2 id="rc-quickselect">RC-QuickSelect</h2>
+<p>Quickly add objects to the current selection set.</p>
+<p>Select objects based on the properties @Name, @Id, @Code, @Type, @Position. If you choose Position, you will be prompted for XY coordinates as well as a radius.</p>
+<p>Note: with V1.0, coordinates must be entered as World coordinates.</p>
+<h2 id="rc-refreshinterlockingdata">RC-RefreshInterlockingData</h2>
+<p>Creates an interlocking data structure containing elementary train routes and shunting routes, then exports them to the selected interlocking objects' "Interlocking" property.</p>
+<p>For train routes or shunting routes to be created, the drawing must contain valid signalling objects with non-empty 'code' properties. It must also be possible to draw at least one path between two such signalling objects.</p>
+<h2 id="rc-refreshobjects">RC-RefreshObjects</h2>
+<p>Updates attachments and refreshes property values derived from attachments.</p>
+<p>Note: Refreshing an object may affect other objects because they might depend on each other.</p>
+<p>The refresh depth can be adjusted in the RailCOMPLETE settings (see command <a href="050-commands.html#rc-settings">RC-Settings</a>).</p>
+<h2 id="rc-refreshtable">RC-RefreshTable</h2>
+<p>Refreshes a RailCOMPLETE table. The current table settings are evaluated again.</p>
+<p>Table settings include object filter, column width and title, Lua formula for each column etc.</p>
+<p>Note: the objects constituting the rows in the table are not refreshed. Refresh all the concerned objects before refreshing a table.</p>
+<h2 id="rc-reloadallxrefs">RC-ReloadAllXRefs</h2>
+<p>Reloads all XRef files.</p>
+<h2 id="rc-reloadxref">RC-ReloadXRef</h2>
+<p>Reloads selected XRefs.</p>
+<h2 id="rc-removeinvalidluaexpressions">RC-RemoveInvalidLuaExpressions</h2>
+<p>Removes Lua expressions with names that do not match a property name.</p>
+<h2 id="rc-removepaths">RC-RemovePaths</h2>
+<p>Removes all paths in drawing.</p>
+<p>Removes paths created with <a href="050-commands.html#rc-setpath">RC-SetPath</a> and <a href="050-commands.html#rc-setpathsfromarea">RC-SetPathsFromArea</a>.</p>
+<h2 id="rc-reorganizeribbontodefault">RC-ReorganizeRibbonToDefault</h2>
+<p>Rebuilds the ribbon and put panels back to the default configuration.</p>
+<p>Use this command if the RailCOMPLETE ribbon tabs are in incorrect order.</p>
+<h2 id="rc-reversealignment">RC-ReverseAlignment</h2>
+<p>Reverses the selected alignments.</p>
+<p>Start point, end point and direction are reversed.</p>
+<p>Linear event profiles are changed to ensure that all alignment characteristics remain the same at each point. E.g., the elevation of each alignment is unchanged at each point. Objects that belong to the alignment will retain their positions, but their linear addresses will be updated.</p>
+<h2 id="rc-rotateucsandview">RC-RotateUcsAndView</h2>
+<p>ToBeDone</p>
+<h2 id="rc-runpatches">RC-RunPatches</h2>
+<p>Lists available patches that needs to be executed on the current drawing.</p>
+<p>You can select and run the patches to apply. You will be warned about possible errors.</p>
+<h2 id="rc-runscript">RC-RunScript</h2>
+<p>Runs a script from a Lua script file.</p>
+<p>Select "Browse" to browse for script file or "Path" to enter a path to the script file. The path can be relative to the main RC install folder or absolute.</p>
+<p>Warning: Running this command from inside a RailCOMPLETE Lua script will not work.</p>
+<h2 id="rc-selectsimilar">RC-SelectSimilar</h2>
+<p>Select all visible objects with the same type as the already selected objects.</p>
+<p>You can select based on type or variant. You also have an option to show only visible objects.</p>
+<h2 id="rc-set2dalignmentdisplayelevation">RC-Set2dAlignmentDisplayElevation</h2>
+<p>Sets the display elevation of 2D alignments at a specified value.</p>
+<p>This value is used when activating the mode to display alignments at elevation (see the command <a href="050-commands.html#rc-display2dalignmentatelevation">RC-Display2dAlignmentAtElevation</a>).</p>
+<h2 id="rc-set2dalignmentdisplayelevationfrompointobject">RC-Set2dAlignmentDisplayElevationFromPointObject</h2>
+<p>Sets the display elevation of 2D alignments at the Z coordinate of the insertion point of a selected point object.</p>
+<p>This value is used when activating the mode to display alignments at elevation (see the command <a href="050-commands.html#rc-display2dalignmentatelevation">RC-Display2dAlignmentAtElevation</a>).</p>
+<h2 id="rc-setalignmentpropertyinpointobject">RC-SetAlignmentPropertyInPointObject</h2>
+<p>Sets alignment reference for the selected point objects.</p>
+<p>You can specify the own alignment for objects and the connection target for all connection objects.</p>
+<h2 id="rc-setnationaltooltipposition">RC-SetNationalTooltipPosition</h2>
+<p>Sets the position of the national tooltip.</p>
+<p>Select between TopLeft, TopRight, BottomRight and BottomLeft.</p>
+<h2 id="rc-setpath">RC-SetPath</h2>
+<p>Visualizes and establishes a navigable path from a starting position to a destination position in a connected graph consisting of alignments and their corresponding connection objects.</p>
+<p>Select a start position and move the cursor around in the network, navigable paths are displayed with a transient thick green line as you roam.</p>
+<p>Once set, the path can be used to check if there is a navigable path from one position to another in your network, for tracks, catenary wires, cable ducts, electrical cables or any other type of connected network. The path can also be used as input to the braking curve tool.</p>
+<p>Tip: to display annotations along a certain part of the alignment(s), use this command to highlight where you need alignment annotation, then display the transient annotations you want along the path (<a href="050-commands.html#rc-showalignmentname">RC-ShowAlignmentName</a> or <a href="050-commands.html#rc-showalignmentmileage">RC-ShowAlignmentMileage</a>). Right-click and select ‘Copy annotations Along Paths to Drawing’. Finally, remove the transient paths (<a href="050-commands.html#rc-removepaths">RC-RemovePaths</a>). The annotations are now displayed along the path only.</p>
+<h2 id="rc-setpathsfromarea">RC-SetPathsFromArea</h2>
+<p>Sets multiple paths in a designated area of the current network.</p>
+<ol>
+<li>
+<p>Select the alignments and draw an area of interest.</p>
+</li>
+<li>
+<p>Click Enter, the paths are shown with a transient thick green line.</p>
+</li>
+</ol>
+<p>You can now use these multiple paths to check if there is a navigable path from one position to another in your network, as input to the braking curve tool, or to display annotations along these paths only in the area of interest.</p>
+<p>See also the command <a href="050-commands.html#rc-setpath">RC-SetPath</a>.</p>
+<h2 id="rc-setpositiontoolalignmentfilter">RC-SetPositionToolAlignmentFilter</h2>
+<p>Sets the filtering of alignments by type.</p>
+<p>Only alignments of the selected type will be used as data source by the position tool.</p>
+<h2 id="rc-setpositiontooldistancealongdisplaymode">RC-SetPositionToolDistanceAlongDisplayMode</h2>
+<p>Sets the position tool to 'Distance along' mode.</p>
+<p>Shows the distance along from the start of an alignment to a point on the alignment, measured along the alignment.</p>
+<p>If the «Ref» alignment button is active, the displayed distance along is instead measured from the start of the reference alignment.</p>
+<h2 id="rc-setpositiontooldistancetoalignmentdisplaymode">RC-SetPositionToolDistanceToAlignmentDisplayMode</h2>
+<p>Shows the distance from a selected point object to its alignment.</p>
+<p>If the Reference alignment option is active, the distance to the reference alignment is shown. If no point object is selected, the current CAD cursor’s position is shown.</p>
+<h2 id="rc-setpositiontoolquantizationmode">RC-SetPositionToolQuantizationMode</h2>
+<p>Locks the values shown by the position tool to the nearest multiple of a given number specified in the DNA.</p>
+<h2 id="rc-setpositiontoolreferencealignmentmode">RC-SetPositionToolReferenceAlignmentMode</h2>
+<p>Sets the position tool to 'Reference' mode.</p>
+<p>The mileage cursor consists of a circle following the own alignment, and a square following the reference alignment. Reference mileage is indicated whenever the Show Position (the mileage indicator line) has been activated.</p>
+<h2 id="rc-setpositiontoolverticalprofiledisplaymode">RC-SetPositionToolVerticalProfileDisplayMode</h2>
+<p>Displays the CAD cursor’s or a point object’s elevation above sea level.</p>
+<p>If a point object is selected, then its elevation is decomposed into the alignment’s elevation, the object’s vertical offset above the alignment, and the absolute elevation (which coincides with the CAD system Z coordinate). If no point object is selected, the current CAD system default Z coordinate is used as a basis.</p>
+<p>If the Reference option is active, the elevation above the reference alignment is shown.</p>
+<h2 id="rc-setreferencealignment">RC-SetReferenceAlignment</h2>
+<p>Sets the Reference Alignment property in the selected alignments.</p>
+<p>The 'Reference Alignment' property is a linear property of an alignment, i.e. a property that can vary along the length of the alignment. Such a property is internally represented as a sequence of distance along values, each associated with an alignment name.</p>
+<p>See also information on the Reference Alignment tab of the Alignment Manager.</p>
+<p>An object 'O' attached to an alignment has a mileage value obtained from the alignment itself, called 'Mileage', generally stated in meters. This object O also has a so-called 'Reference Mileage', generally stated in meters, which is obtained from the object O's so-called 'Reference alignment'. The reference alignment is usually common to all individual alignments in a given area and makes it possible to order point objects along this common Linear Element (ref. ISO 19148:2012).</p>
+<p>The 'Reference Alignment' property is a linear property of object O's own alignment, that is, it can vary along the axis. An axis can refer to different alignments depending on the position. The Reference Alignment property is internally represented by a sequence of distance along values, each associated with an alignment identifier. The alignment names defined in the Reference Alignment linear property can be void or can identify another alignment in the CAD model. See also the <a href="050-commands.html#rc-managealignments">RC-ManageAlignments</a> command.</p>
+<p>A newly created alignment 'A' holds no Reference Alignment property yet. In this case, alignment A implicitly uses itself as Reference Alignment from its starting DistanceAlong=0 to its maximum DistanceAlong=L. An object O which belongs to this alignment A will report its Mileage when asked about its position expressed as Reference Mileage, because alignment A has not yet nominated another alignment as its reference alignment. The Mileage of object O is defined as object O’s linear address with respect to its own alignment A, expressed as Mileage values [m] and not as distance along values (see below).</p>
+<p>Note 1: The position along an axis (Distance along) varies between 0 and 'L' in the direction of increasing mileages, L being the 2D length of the axis.</p>
+<p>Note 2: 'Mileage' is a saw-tooth function in a alignment starting from 0 or from an explicitly assigned start mileage value and thereafter increasing linearly with distance along. At given distance alongs, the Mileage sawtooth function can experience a so-called 'chain break' and jump to a new value.</p>
+<p>Note 3: The linear address of an object is obtained by orthogonal projection of the insertion point of the object onto the horizontal geometry of the axis to which it is attached. The projection is made in the XY plane and does not take into account the vertical profile or the cant of the axis.</p>
+<p>Note 4: If object O’s own alignment A has nominated alignment B as Reference Alignment in the distance along interval where object O finds its Mileage with respect to A, then object O will report its linear address with respect to alignment B when asked about its Reference mileage. To find object O’s linear address with respect to alignment A we construct a line in the XY plane orthogonal to A’s horizontal geometry and passing through O’s insertion point. Observe that alignment A’s vertical profile and cant are not used in the calculation of linear address. Observe that Mileage can be ambiguous if the alignment’s Mileage function has negative chain breaks.</p>
+<h2 id="rc-setrelationrefreshdepth">RC-SetRelationRefreshDepth</h2>
+<p>Sets the depth in of which objects will be updated when an object is changed.</p>
+<p>The depth is the number of relations to get to the changed object.</p>
+<h2 id="rc-settings">RC-Settings</h2>
+<p>Opens the Settings dialog box.</p>
+<p>There are two categories of settings: user settings and drawing settings.</p>
+<p>User settings are global settings that are stored in your CAD system's current profile. They apply to all drawings you open.</p>
+<p>Drawing settings are set for each drawing individually.</p>
+<h2 id="rc-show2dprojection3dsourcepreview">RC-Show2dProjection3dSourcePreview</h2>
+<p>Shows a preview of 3D geometries for objects captured inside the selected point object's box.</p>
+<p>Each 2D projection is based on the 3D source geometries captured by the projection's box.</p>
+<p>The box - possibly rotated in 3D - is projected onto the World Coordinate System XY plane to create a virtual polygon (which will be either square or hexagonal).</p>
+<ul>
+<li>
+<p>Visible point objects, where the insertion point's XY coordinates fall inside this polygon, are included in the 3D source collection.</p>
+</li>
+<li>
+<p>Alignments which are completely or partially inside the virtual polygon will be included.</p>
+</li>
+<li>
+<p>Extra object references can be added to the 'IncludeObjects' collection.</p>
+</li>
+<li>
+<p>Objects contained in the 'ExcludeObjects' collection will removed from the selection set before 2D projection takes place.</p>
+</li>
+</ul>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-show2dprojectionboxpreview">RC-Show2dProjectionBoxPreview</h2>
+<p>Shows a preview of the box defining the 3D geometries that will be the source of the next 2D projection.</p>
+<p>The box is defined by its diagonally opposite 3D corners' properties 'MinimumBound' and 'MaximumBound', possibly rotated in 3D space.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-show2dprojectionpreview">RC-Show2dProjectionPreview</h2>
+<p>Shows a preview of the 2D projection for the selected point objects.</p>
+<p>The source 3D geometries are projected onto the front of the box.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-show3dpreview">RC-Show3dPreview</h2>
+<p>Shows selected objects as transient annotations in 3D.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer as one common block.</p>
+<p>The following export settings are used and cannot be changed: - 3D library folders are taken from the '<a href="050-commands.html#rc-export3d">RC-Export3d</a>' settings. - Defpoints are enabled. - Logging is disabled. - The output is all sent to a layer specified in the drawing settings, found with the '<a href="050-commands.html#rc-settings">RC-Settings</a>' command. If you want to change this behavior, use the '<a href="050-commands.html#rc-export3d">RC-Export3d</a>' or '<a href="050-commands.html#rc-export3dusingcurrentsettings">RC-Export3dUsingCurrentSettings</a>' command instead.</p>
+<h2 id="rc-showalignmentgeometry">RC-ShowAlignmentGeometry</h2>
+<p>Displays transient alignment geometry markers along the selected alignments.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<p>Alternatively, you can annotate alignments only within the extent of a given path. Create a path, for instance with <a href="050-commands.html#rc-setpath">RC-SetPath</a> or <a href="050-commands.html#rc-setpathsfromarea">RC-SetPathsFromArea</a>, then use 'Copy Annotations Along Paths to Drawing' from the context menu.</p>
+<h2 id="rc-showalignmentmileage">RC-ShowAlignmentMileage</h2>
+<p>Displays transient mileage markers along the selected alignments.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showalignmentname">RC-ShowAlignmentName</h2>
+<p>DIsplays transient alignment name markers along the selected alignments.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<p>Alternatively, you can annotate alignments only within the extent of a given path. Create a path, for instance with <a href="050-commands.html#rc-setpath">RC-SetPath</a> or <a href="050-commands.html#rc-setpathsfromarea">RC-SetPathsFromArea</a>, then use 'Copy Annotations Along Paths to Drawing' from the context menu.</p>
+<h2 id="rc-showalignmentprofile">RC-ShowAlignmentProfile</h2>
+<p>Displays transient profile markers along the selected alignments.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<p>Alternatively, you can annotate alignments only within the extent of a given path. Create a path, for instance with <a href="050-commands.html#rc-setpath">RC-SetPath</a> or <a href="050-commands.html#rc-setpathsfromarea">RC-SetPathsFromArea</a>, then use 'Copy Annotations Along Paths to Drawing' from the context menu.</p>
+<h2 id="rc-showannotationinfo">RC-ShowAnnotationInfo</h2>
+<p>Shows extra information, if available, when hovering over transient annotations.</p>
+<h2 id="rc-showdnareleasenotes">RC-ShowDnaReleaseNotes</h2>
+<p>Opens the DNA release notes.</p>
+<h2 id="rc-showearthing">RC-ShowEarthing</h2>
+<p>Displays earthing by showing transient lines between an object and its protective earth-providing object or alignment (PE).</p>
+<p>The 'source' is the object to be earthed. The 'target' is the earth provider. A 'blob' may be shown at the source and at the target. Modify or suppress these blobs using <a href="050-commands.html#rc-settings">RC-Settings</a>.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showfoulingpoints">RC-ShowFoulingPoints</h2>
+<p>Displays fouling points.</p>
+<p>Use <a href="050-commands.html#rc-settings">RC-Settings</a> to select between the available algorithms.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showinsertionpointinheritance">RC-ShowInsertionPointInheritance</h2>
+<p>Displays transient connection lines between a point object and the insertion point of the point object that it has been attached to.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showlayergroups">RC-ShowLayerGroups</h2>
+<p>Shows or hides predefined layer groups.</p>
+<p>Layer groups are configured in the administration’s DNA (not in the AutoCAD layer manager).</p>
+<p>To delete, add or modify such layer groups, contact your local administrator or your RailCOMPLETE agent.</p>
+<h2 id="rc-showmileagechange">RC-ShowMileageChange</h2>
+<p>Displays transient mileage change (aka 'chain break') symbols along the selected alignments.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showownalignment">RC-ShowOwnAlignment</h2>
+<p>Displays transient connection lines between an object and the alignment it belongs to.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showposition">RC-ShowPosition</h2>
+<p>Displays the CAD cursor's linear address. The transient line and the transient square symbol indicate where the linear address measurement is made.</p>
+<p>Mileage and Reference Mileage constitute alternative ways of expressing a linear position.</p>
+<p><strong>Basic mode</strong></p>
+<p>In Basic Mode, the <strong>Mileage</strong> property is a linear position computed along an object's <strong>own alignment</strong> (or from the CAD cursor and a given alignment), being the sum of that alignment's assigned start mileage and the distance along that alignment's 2D geometry up to the object's 2D projection onto the alignment. The mileage value may be increased or decreased by mileage changes occurring between the alignment's start and the projection. These mileage changes can be inspected and modified in the Alignment Manager's 'Mileage/Mileage Changes' tab.</p>
+<p><strong>Reference Mode</strong></p>
+<p>In Reference Mode, the measurement is made relative to a <strong>Reference Alignment</strong>, usually one that represents the overall corridor's geometry in a railway project. All tracks will be referred to this common reference when computing linear positions for as-built documentation.</p>
+<p>An object's own alignment in RailCOMPLETE holds a data structure that contains a segmentation that subdivides the geometry from start to end. Each segment holds the identity of another alignment, being the associated reference alignment for positions that belong to that segment. The segmentation can be inspected and modified in the Alignment Manager's 'Reference Alignment' tab. An alignment can change reference alignment along its segmentation, because railway lines / corridors may split or join, and each individual railway line / corridor needs its own reference alignment. Reference alignments are typically long, extending continuously from one end to the other of a railway project. Several RailCOMPLETE tools depend on the existence of a well-defined reference alignment and appropriate reference alignment segmentation in the individual tracks (alignments).</p>
+<p><strong>TwoStep Method</strong></p>
+<p>The "TwoStep" method is one of two methods used to determine the <strong>ReferenceMileage</strong> property. This method conforms with <strong>ISO 19148:2012 Linear Referencing</strong>, see Figure 7 "Linearly referenced offset location O with an offset referent". A given 2D point 'O' is first projected onto point 'RO' belonging to the source object's own alignment (being called the 'offset referent' in ISO 19148). RailCOMPLETE then consults at point RO the segmentation contained in the own alignment to obtain the ID of the appropriate reference alignment to use in the second step. Point RO is then projected onto a point A belonging to the reference alignment that we just determined. The ReferenceMileage of point O belonging to its own alignment is defined as the Mileage of point A in the reference alignment </p>
+<p>Major railway administrations such as SNCF and DB Netz use the two-step method.</p>
+<p><strong>Direct Method</strong></p>
+<p>In the "Direct" method, point O (not RO) is projected directly onto the reference alignment to find point A.</p>
+<p>The Norwegian railway administration Bane NOR uses the direct method.</p>
+<p>Available modes are:</p>
+<ul>
+<li>
+<p>Reference: Displays measurement related to the current reference alignment, as opposed to own alignment measurements.</p>
+</li>
+<li>
+<p>Distance to alignment: Displays the shortest possible horizontal distance from cursor to the currently picked-up alignment.</p>
+</li>
+<li>
+<p>Elevation: Displays the elevation (Z) at the point 'RO', the cursor's projection onto current 'own alignment'.</p>
+</li>
+<li>
+<p>Distance Along: Displays the distance from start-of-alignment to point 'RO' in own alignment (in non-reference mode) or to point 'A' in reference alignment (in Reference mode).</p>
+</li>
+<li>
+<p>Quantize: Truncates the linear address measurement to the nearest integer multiple of the current quantization step (*).</p>
+</li>
+<li>
+<p>Bind: Binds own alignment to be the last selected alignment of any type. Bind takes precedence over Filter.</p>
+</li>
+<li>
+<p>Filter: Select an alignment type from the currently available alignment types in your model.</p>
+</li>
+</ul>
+<p>REFERENCE MODE - INDIRECT LINEAR REFERENCING</p>
+<p>Every point object may belong to exactly one alignment, known as the object's 'Own Alignment'. Alternatively, we may consider the CAD cursor, which picks up the closest point on the closest alignment (**).</p>
+<p>Every alignment has an internal segmentation where each segment refers to another alignment, or refers to itself. The referenced alignment that corresponds to a given position along the own alignment is known as that position's 'Reference Alignment' (***).</p>
+<p>In [1], the pickup point is referred to as point 'O', and Own Alignment is referred to as the 'Offset Referent'. The pick-up point 'O' is projected orthogonally onto the own alignment / the offset referent at point 'RO'. 'RO' is visualized with a circle, and with a dashed line passing through the pick-up point 'O' and being perpendicular to own alignment.</p>
+<p>RailCOMPLETE now reads the segmentation at the pick-up point's projection 'RO' and thereby knows which is the corresponding reference alignment. [1] uses the term "Linear Element" to signify this reference alignment.</p>
+<p>Point 'RO' in own alignment is then projected orthogonally onto point 'A' in the reference alignment. Point 'A' is visualized with a square, and with a solid line passing through 'A' and being perpendicular to the reference alignment. A linear address measurement is made at point 'A', known as a "Reference Mileage" value (****). The linear measurement is displayed at the CAD cursor along with its SI unit.</p>
+<p>Note: Some railway administrations, e.g. Norwegian Bane NOR, project point 'O' (instead of 'RO') perpendicularly onto a point 'B' in the reference alignment. In general, 'B' is slightly different from 'A', being identical only if the own alignment's and the reference alignment's tangent directions are locally identical. This alternative behaviour is selected in the DNA.</p>
+<p>NON-REFERENCE MODE - DIRECT LINEAR REFERENCING</p>
+<p>If Reference mode has been deactivated then the measurement is made in own alignment at point 'RO'. In ISO 19148 terminology, own alignment is now the Linear Element. This measurement is known as "Mileage".</p>
+<p>ABSOLUTE AND RELATIVE LINEAR REFERENCING METHODS</p>
+<p>Both the direct and the indirect linear referencing methods may use Absolute Linear Referencing or Relative Linear Referencing . An absolute measurement is a distance along own alignment / reference alignment from this linear element's start to the projection RO/A/B, possibly featuring a 'jump' at discrete points, known as 'Chain Breaks'. A relative measurement uses suitable point objects along the linear element as 'Milestones' and presents a measurement as the name of the closest preceding milestone plus the distance along the linear element from that milestone's projection onto the linear element to the point RO/A/B. An object acting as a milestone is known as a 'Referent' of type 'REFERENCEMARKER' in [1].</p>
+<p><em>Notes</em></p>
+<p>(*) Inspect or modify current quantization step in <a href="050-commands.html#rc-settings">RC-Settings</a>. The Quantization mode also affects the operations of copy and move commands, on condition that the Position tool is active.</p>
+<p>(**) The alignment pick-up process is influenced by the Filter mode and by the Bind mode.</p>
+<p>(***) This segmentation can be edited in using <a href="050-commands.html#rc-managealignments">RC-ManageAlignments</a>, the 'Reference Alignment' tab.</p>
+<p>(****) Depending on DNA declarations, the Linear Referencing Method may correspond to one of the standardized methods in [1].</p>
+<p>References:</p>
+<p>[1] ISO 19148:2012, Linear Referencing, Figure 7. The document explains the concepts of Linear Referencing Methods (LRM) and position expressions.</p>
+<h2 id="rc-showreferencealignment">RC-ShowReferenceAlignment</h2>
+<p>Displays transient reference alignments along the selected alignments.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<p>Alternatively, you can annotate alignments only within the extent of a given path. Create a path, for instance with <a href="050-commands.html#rc-setpath">RC-SetPath</a> or <a href="050-commands.html#rc-setpathsfromarea">RC-SetPathsFromArea</a>, then use 'Copy Annotations Along Paths to Drawing' from the context menu.</p>
+<h2 id="rc-showreferencealignmentmileage">RC-ShowReferenceAlignmentMileage</h2>
+<p>Displays transient reference mileage markers along the selected alignments, but only in the intervals where the alignment is its own reference.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<p>Alternatively, you can annotate alignments only within the extent of a given path. Create a path, for instance with <a href="050-commands.html#rc-setpath">RC-SetPath</a> or <a href="050-commands.html#rc-setpathsfromarea">RC-SetPathsFromArea</a>, then use 'Copy Annotations Along Paths to Drawing' from the context menu.</p>
+<h2 id="rc-showrelations">RC-ShowRelations</h2>
+<p>Displays transient relation lines between a selected object and its related objects.</p>
+<p>Solid relation lines represent forward direction relations, dashed relation lines represent reverse direction relations.</p>
+<p>Activate the <a href="050-commands.html#rc-showannotationinfo">RC-ShowAnnotationInfo</a> tool to see more information on the object's relations.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showsections">RC-ShowSections</h2>
+<p>Displays the selected section object's extents between its section delimiters in a topologically connected network.</p>
+<p>Make annotations permanent in drawing using 'Copy Annotations to Drawing' from the context menu. They are placed on AutoCAD's current layer.</p>
+<h2 id="rc-showtworails">RC-ShowTwoRails</h2>
+<p>Toggles between a single-line and a two-line representation of all alignments.</p>
+<h2 id="rc-showversion">RC-ShowVersion</h2>
+<p>Prints the current RailCOMPLETE installation's version to the CAD command window.</p>
+<h2 id="rc-showvideos">RC-ShowVideos</h2>
+<p>Opens the RailCOMPLETE demo videos.</p>
+<h2 id="rc-showwarningincadtextwindow">RC-ShowWarningInCadTextWindow</h2>
+<p>Defines where the CAD's warnings are shown.</p>
+<p>Choose between:</p>
+<ul>
+<li>
+<p>0: Write to command line.</p>
+</li>
+<li>
+<p>1: Show dialog boxes.</p>
+</li>
+</ul>
+<h2 id="rc-support">RC-Support</h2>
+<p>Ask for support.</p>
+<p>Send mail to support@railcomplete.com.</p>
+<h2 id="rc-ungroupballoons">RC-UngroupBalloons</h2>
+<p>Ungroup balloon objects that are grouped together.</p>
+<h2 id="rc-unloadxref">RC-UnloadXRef</h2>
+<p>Unloads selected XRefs.</p>
+<h2 id="rc-updatearea">RC-UpdateArea</h2>
+<p>Reloads the Areas in the drawing.</p>
+<h2 id="rc-updatednawithmapping">RC-UpdateDnaWithMapping</h2>
+<p>Updates the RailCOMPLETE document to a new DNA version using a mapping file.</p>
+<p>All RailCOMPLETE objects are expressed using names, property definitions, enum values, default values and Lua formulas from the current DNA. In the DNA update process, each RailCOMPLETE object is analyzed and its contents are translated to be consistent with the new DNA's declarations. The mapping file provides the translation between the source and target DNA.</p>
+<p>For the DNA update process to work, the competent user, or a RailCOMPLETE Agent, must have created a DNA mapping file using the option Create DNA Mapping (command <a href="050-commands.html"></a>).</p>
+<h2 id="rc-webpagesandfaq">RC-WebPagesAndFAQ</h2>
+<p>Opens an information resources page with useful info and links.</p>
+<h2 id="rc-xrefselectoff">RC-XRefSelectOff</h2>
+<p>Turns off the selection mode for selecting components within an XRef.</p>
+<p>The XRef will be treated as a separate entity.</p>
+<h2 id="rc-xrefselecton">RC-XRefSelectOn</h2>
+<p>Turns on the selection mode for selecting components within an XRef.</p>
+<p>To select the xref itself, use the ‘green/blue’ or the lasso selection method in the CAD editor (swipe an area somewhere over the xref).</p>
+<p><em>Note: The CAD system does not allow to select individual objects in an XRef from an already running command. Commands needing a selection set containing objects in one or more XRefs must get these in a 'PICKFIRST' selection set, i.e. they must have been be selected prior to launching the command.</em></p>
+<h2 id="refedit">REFEDIT</h2>
+<p>Edits an xref directly within the current drawing.</p>
+<p>The objects that you select from the selected xref are temporarily extracted and made available for editing in the current drawing. The set of extracted objects is called the working set, which can be modified and then saved back to update the xref or block definition.</p>
+              
+            </div>
+          </div><footer>
+    <div class="rst-footer-buttons" role="navigation" aria-label="Footer Navigation">
+        <a href="040-qa.html" class="btn btn-neutral float-left" title="Q&A"><span class="icon icon-circle-arrow-left"></span> Previous</a>
+        <a href="060-export3d.html" class="btn btn-neutral float-right" title="Export 3D">Next <span class="icon icon-circle-arrow-right"></span></a>
+    </div>
+
+  <hr/>
+
+  <div role="contentinfo">
+    <!-- Copyright etc -->
+      <p>&copy Railcomplete AS, 2025</p>
+  </div>
+
+  Built with <a href="https://www.mkdocs.org/">MkDocs</a> using a <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+</footer>
+          
+        </div>
+      </div>
+
+    </section>
+
+  </div>
+
+  <div class="rst-versions" role="note" aria-label="Versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    
+    
+      <span><a href="040-qa.html" style="color: #fcfcfc">&laquo; Previous</a></span>
+    
+    
+      <span><a href="060-export3d.html" style="color: #fcfcfc">Next &raquo;</a></span>
+    
+  </span>
+</div>
+    <script src="js/jquery-3.6.0.min.js"></script>
+    <script>var base_url = ".";</script>
+    <script src="js/theme_extra.js"></script>
+    <script src="js/theme.js"></script>
+      <script src="search/main.js"></script>
+    <script>
+        jQuery(function () {
+            SphinxRtdTheme.Navigation.enable(true);
+        });
+    </script>
+
+</body>
+</html>

--- a/.claude/references/070-lua.html
+++ b/.claude/references/070-lua.html
@@ -1,0 +1,813 @@
+<!DOCTYPE html>
+<html class="writer-html5" lang="en" >
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="author" content="Railcomplete AS" />
+      <link rel="shortcut icon" href="img/favicon.ico" />
+    <title>Lua - RailCOMPLETE Reference Manual</title>
+    <link rel="stylesheet" href="css/theme.css" />
+    <link rel="stylesheet" href="css/theme_extra.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" />
+        <link href="extra.css" rel="stylesheet" />
+    
+      <script>
+        // Current page data
+        var mkdocs_page_name = "Lua";
+        var mkdocs_page_input_path = "070-lua.md";
+        var mkdocs_page_url = null;
+      </script>
+    
+    <!--[if lt IE 9]>
+      <script src="js/html5shiv.min.js"></script>
+    <![endif]-->
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/lua.min.js"></script>
+      <script>hljs.highlightAll();</script> 
+</head>
+
+<body class="wy-body-for-nav" role="document">
+
+  <div class="wy-grid-for-nav">
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
+    <div class="wy-side-scroll">
+      <div class="wy-side-nav-search">
+<a href="./index.html" class="icon icon-home"> RailCOMPLETE Reference Manual</a><div role="search">
+  <form id ="rtd-search-form" class="wy-form" action="./search.html" method="get">
+      <input type="text" name="q" placeholder="Search docs" aria-label="Search docs" title="Type search term here" />
+  </form>
+</div>
+      </div>
+
+      <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
+    
+		<div style="display: inline-block;">
+												
+					
+					<a href="./070-lua.html">
+						<img style="height: 15px;" alt="English" src="./img/flags/en.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./fr/070-lua.html">
+						<img style="height: 15px;" alt="Français" src="./img/flags/fr.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./de/070-lua.html">
+						<img style="height: 15px;" alt="Deutsch" src="./img/flags/de.png" />
+					</a>
+					
+				
+
+			</div>
+		
+    
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="index.html">Welcome</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="010-gettingstarted.html">Getting started</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="020-mainfeatures.html">Main features</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="030-tipsandtricks.html">Tips and tricks</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="035-LinearReferencing.html">Linear Referencing</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="040-qa.html">Q&A</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="050-commands.html">RailCOMPLETE commands</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="060-export3d.html">Export 3D</a>
+				</li>
+			</ul>
+			<ul class="current">
+				<li class="toctree-l1 current"><a class="reference internal current" href="070-lua.html">Lua</a>
+    <ul class="current">
+    <li class="toctree-l2"><a class="reference internal" href="#lua-syntax-introduction">Lua Syntax Introduction</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#comments">Comments</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#lua-types">Lua Types</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#variables">Variables</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#dynamic-typing">Dynamic typing</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#functions">Functions</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#tables">Tables</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#object-oriented-programming-in-lua">Object Oriented Programming in Lua</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#useful-links">Useful links</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#expressions-tutorial">Expressions Tutorial</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#arithmetic-expressions">Arithmetic expressions</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#relational-expressions">Relational expressions</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#logical-operators">Logical operators</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#ternary-operators">Ternary operators</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#control-structure-tutorial">Control Structure Tutorial</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#if-statement">if statement</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#loops">Loops</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#while-loop">While loop</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#repeat-loop">Repeat loop</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#numeric-for-loop">Numeric for loop</a>
+    </li>
+        </ul>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#formulas">Formulas</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#general">General</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#filter-formula">Filter formula</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#map-formula">Map formula</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#filter-map">Filter-map</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#display-name-vs-property">Display Name VS Property</a>
+    </li>
+    </ul>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="080-luacommands.html">Lua Functions</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="080-luadebugger.html">Lua debugger</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="090-classdiagrams.html">Class Diagrams</a>
+				</li>
+			</ul>
+      </div>
+    </div>
+    </nav>
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+      <nav class="wy-nav-top" role="navigation" aria-label="Mobile navigation menu">
+          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+          <a href="index.html">RailCOMPLETE Reference Manual</a>
+        
+      </nav>
+      <div class="wy-nav-content">
+        <div class="rst-content"><div role="navigation" aria-label="breadcrumbs navigation">
+  <ul class="wy-breadcrumbs">
+    <li><a href="index.html" class="icon icon-home" aria-label="Docs"></a></li>
+      <li class="breadcrumb-item active">Lua</li>
+    <li class="wy-breadcrumbs-aside">
+    </li>
+  </ul>
+  <hr/>
+</div>
+          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+            <div class="section" itemprop="articleBody">
+              
+                <h1 id="lua">Lua</h1>
+<p>Lua is a lightweight, dynamically typed, strongly typed scripting language based on standard C, made by PetroBras, Brazil. In RailCOMPLETE, Lua is used primarily as a scripting language in formulas for RailwayObject properties.
+It is also used in the table tool for defining object filters and for specifying cell value content.</p>
+<h2 id="lua-syntax-introduction">Lua Syntax Introduction</h2>
+<h3 id="comments">Comments</h3>
+<p>Double hyphen ( -- ) starts commenting on the line. Multiline comments are started with double hyphen followed by double square brackets ( --[[ ) and run until it encounters double closing square brackets ( ]] ).</p>
+<pre><code class="language-lua">-- This is a short comment
+
+--[[
+This is a long comment
+and over multiple lines
+--]] -- It is customary to append the double hyphen in front of the brackets
+
+--[==[     &lt;-- Comment will run until double square closing brackets with the same number of equal signs in-between
+Useful if you want to comment out code with double closing square brackets in it
+--]==]
+</code></pre>
+<h3 id="lua-types">Lua Types</h3>
+<p>There are only 8 basic types in Lua.</p>
+<ul>
+<li><em>nil</em>: Usually used to signify absence of a value. <em>nil</em> also makes a condition false.</li>
+<li><em>boolean</em>: true or false.</li>
+<li><em>number</em>:</li>
+<li><em>integer</em>: Whole numbers</li>
+<li><em>float</em>: Real number, i.e. numbers with a decimal point</li>
+<li><em>string</em>: Used to hold text</li>
+<li><em>function</em>: Holds reference to a function</li>
+<li><em>table</em>: Associative array, used as arrays, lists, dictionaries, etc.</li>
+<li><em>userdata</em>: Data from C API. RC objects will be of type <em>userdata</em></li>
+<li><em>threads</em>: N/A</li>
+</ul>
+<h3 id="variables">Variables</h3>
+<p>Variables which are declared without the <em>local</em> keyword in front are accessible everywhere after assignment, while those with <em>local</em> are only accessible in the current <em>scope</em> (in the current function). It is good practice to use local variables and only global when necessary.</p>
+<pre><code class="language-lua">a = 5 -- Assignment of global variable 'a'
+local b = 4 -- Assignment of local variable 'b'
+</code></pre>
+<h3 id="dynamic-typing">Dynamic typing</h3>
+<p>Variables in Lua do not have types; only the values do. This means that we can assign values of different types to the same variable.</p>
+<pre><code class="language-lua">a = 5
+type(a) -- Output: number
+b = &quot;5&quot;
+type(b) -- Output: string
+a = &quot;test&quot; -- 'a' now contains a string
+type(a) -- Output: string
+</code></pre>
+<h3 id="functions">Functions</h3>
+<p>Functions in Lua are first-class values, which means that functions are stored as values in variables.</p>
+<pre><code class="language-lua">function add(x, y) -- this is the same as add = function(x, y)
+    sum = x + y
+    return sum
+end
+
+return add(5, 4) -- Output: 9
+</code></pre>
+<h3 id="tables">Tables</h3>
+<p>Tables is Lua's only data structure mechanism. Tables are hash tables, i.e. key/value pairs, but they are used as arrays, objects and every other data structure. Tables can be accessed as an indexed table (array, multi-dimensional) or as a list. You can do index operations and amount operations on a table.</p>
+<p>Tables can contain values of any kind. Table values are accessed with the form <em>table_name["key"]</em>, or the shorter version <em>table_name.key = value</em>. The key does not have to be a string, but then the shorter version is not available.
+If the key is omitted in the table constructor, the key will be the index, starting from 1.</p>
+<pre><code class="language-lua">b = {'a', 'b'} -- the same as b = {[1] = 'a', [2] = 'b'}
+assert(b[1] == 'a') -- true
+
+a = {first = &quot;string 1&quot;, second = &quot;string 2&quot;} -- the same as a = {[&quot;first&quot;] = &quot;string 1&quot;, etc.
+assert(a[&quot;first&quot;] == &quot;string 1&quot;) -- true
+assert(a.second == &quot;string 2&quot;) -- true
+assert(a[&quot;this doesn't exist&quot;] == nil) -- true
+</code></pre>
+<h3 id="object-oriented-programming-in-lua">Object Oriented Programming in Lua</h3>
+<p>Although Lua doesn't have classes, it is possible to emulate classes through tables.</p>
+<pre><code class="language-lua">a = {sum = 0, add=function(self, x) self.sum = self.sum + x end}
+a.add(a, 3)
+assert(a.sum == 3) -- true
+
+b = {sum = 0}
+function b:add(x) -- shorthand for b[&quot;add&quot;] = function(self, x)
+    self.sum = self.sum + x
+end
+b:add(7) -- shorthand for b.add(b, 7)
+assert(b.sum == 7) -- true
+</code></pre>
+<h3 id="useful-links">Useful links</h3>
+<p><a href="https://www.formsbank.com/download/300662/the-lua-language-v5-1-cheat-sheet.html">Download Lua Cheat Sheet</a></p>
+<p><a href="https://www.lua.org/manual/5.4/manual.html">Lua 5.4 Reference Manual</a></p>
+<h2 id="expressions-tutorial">Expressions Tutorial</h2>
+<p>Expressions are evaluated in order to perform calculations which may assign values to variables or pass arguments
+to functions. Expressions are covered pretty well in section 2.5 of the Reference Manual.[1] Expressions are covered
+here for completeness and to offer more examples. We'll use the = expression shorthand notation for this page. The
+values can easily be assigned to a variable, e.g.,</p>
+<pre><code class="language-lua">x = 7
+return x
+
+-- Output: 7
+</code></pre>
+<h3 id="arithmetic-expressions">Arithmetic expressions</h3>
+<p>Lua has the usual binary arithmetic operators.</p>
+<pre><code class="language-lua">2+3, 5-12, 2*7, 7/8
+
+-- Output: Collection(4) {5, -7, 14, 0.875}
+</code></pre>
+<pre><code class="language-lua">5*(2-8.3)/77.7+99.1
+
+-- Output: 98.6945945945946
+
+</code></pre>
+<p><em>Unary negation:</em></p>
+<pre><code class="language-lua">-(-10), -(10)
+
+-- Output: Collection(2) {10, -10}
+</code></pre>
+<p><em>Modulo (division remainder):</em></p>
+<pre><code class="language-lua">15%7, -4%3, 5.5%1
+
+-- Output: Collection(3) {1, 2, 0.5}
+</code></pre>
+<p><em>Power of:</em></p>
+<pre><code class="language-lua">7^2, 107^0, 2^8
+
+-- Output: Collection(3) {49, 1, 256}
+
+</code></pre>
+<h3 id="relational-expressions">Relational expressions</h3>
+<p>Relational operators are supplied which return the boolean values true or false.</p>
+<ul>
+<li>== equal to</li>
+<li>~= not equal to</li>
+<li>&lt; less than</li>
+<li>&gt; greater than</li>
+<li>&lt;= less than or equal to</li>
+<li>&gt;= greater than or equal to</li>
+</ul>
+<p>Examples:</p>
+<pre><code class="language-lua">1 == 1, 1 == 0
+
+-- Output: Collection(2) {True, False}
+
+1 ~= 1, 1 ~= 0
+
+-- Output: Collection(2) {False, True}
+
+
+3 &lt; 7, 7 &lt; 7, 8 &lt; 7
+
+-- Output: Collection(3) {True, False, False}
+
+
+3 &gt;= 7, 7 &gt;= 7, 8 &gt;= 7
+
+-- Output: Collection(3) {False, True, True}
+</code></pre>
+<p>These also work on strings and other types.</p>
+<pre><code class="language-lua">&quot;abc&quot; &lt; &quot;def&quot;
+
+-- Output: True
+
+&quot;abc&quot; &gt; &quot;def&quot;
+
+-- Output: False
+
+&quot;abc&quot; == &quot;abc&quot;
+
+-- Output: True
+
+&quot;abc&quot; == &quot;a&quot;..&quot;bc&quot;
+
+-- Output: True
+</code></pre>
+<p>Objects will not be equal if the types are different or refer to different objects.</p>
+<pre><code class="language-lua">{} == &quot;table&quot;
+
+-- Output: False
+
+
+-- two different tables are created here
+{} == {}  
+
+-- Output: False
+
+t = {}
+t2 = t
+
+-- we're referencing the same table here
+return t == t2   
+
+-- Output: True
+</code></pre>
+<p>Coercion does not work here, the types must be converted explicitly.</p>
+<pre><code class="language-lua">&quot;10&quot; == 10
+
+-- Output: False
+
+tonumber(&quot;10&quot;) == 10
+
+-- Output: True
+</code></pre>
+<h3 id="logical-operators">Logical operators</h3>
+<p>Lua provides the logical operators <em>and</em>, <em>or</em> and <em>not</em>. In Lua both nil and the boolean value false represent false in a logical expression.
+Anything that is not false (either nil or false) is true. There are more notes on the implications of this at the end of this page.</p>
+<pre><code class="language-lua">false==nil   -- although they represent the same thing they are not equivalent
+
+-- Output: False
+
+true==false, true~=false
+
+-- Output: Collection(2) {False, True}
+
+does_this_exist  -- test to see if variable &quot;does_this_exist&quot; exists. no, false.
+
+-- Output: null
+</code></pre>
+<p><strong>Logical operator <em>not</em></strong></p>
+<p>The keyword not inverts a logical expression value:</p>
+<pre><code class="language-lua">true, false, not true, not false
+
+-- Output: Collection(4) {True, False, False, True}
+
+not nil       -- nil represents false
+
+-- Output: True
+
+not not true  -- true is not not true!
+
+-- Output: True
+
+not &quot;foo&quot;     -- anything not false or nil is true
+
+-- Output: False
+</code></pre>
+<p><strong>Logical operator <em>and</em></strong></p>
+<p>The binary operator and does not necessarily return a boolean value true or false to the logical expression x and y. In some languages the and operator returns a boolean dependent on the two inputs. Rather in Lua, it returns the first argument if its value is false or nil, and the second argument if the first argument is not false or nil. So, a boolean is only returned if the first argument is false or the second argument is a boolean.</p>
+<pre><code class="language-lua">false and true  -- false is returned because it is the first argument
+
+-- Output: False
+
+nil and true    -- as above
+
+-- Output: null
+
+nil and false
+
+-- Output: null
+
+nil and &quot;hello&quot;, false and &quot;hello&quot;
+-- null is removed from collection that is returned
+
+-- Output: False
+</code></pre>
+<p>All of the above expressions return the first argument. All of the following expressions return the second argument, as the first is true.</p>
+<pre><code class="language-lua">true and false
+
+-- Output: False
+
+true and true
+
+-- Output: True
+
+1 and &quot;hello&quot;, &quot;hello&quot; and &quot;there&quot;
+
+-- Output: Collection(2) {hello, there}
+
+true and nil
+
+-- Output: null
+</code></pre>
+<p>As you can see the logical expressions are still evaluated correctly but we have some interesting behaviour because of the values returned.</p>
+<p><strong>Logical operator <em>or</em></strong></p>
+<p>The or binary operator also does not necessarily return a boolean value (see notes for and above). If the first argument is not false or nil it is returned, otherwise the second argument is returned. So, a boolean is only returned if the first argument is true or the second argument is a boolean.</p>
+<pre><code class="language-lua">true or false
+
+-- Output: True
+
+true or nil
+
+-- Output: True
+
+&quot;hello&quot; or &quot;there&quot;, 1 or 0
+
+-- Output: Collection(2) {hello, 1}
+</code></pre>
+<p>All of the above expressions return the first argument. All of the following expressions return the second argument, as the first is false or nil.</p>
+<pre><code class="language-lua">false or true
+
+-- Output: True
+
+nil or true
+
+-- Output: True
+
+nil or &quot;hello&quot;
+
+-- Output: hello
+</code></pre>
+<p>This can be a very useful property. For example, setting default values in a function:</p>
+<pre><code class="language-lua">function foo(x)
+  local value = x or &quot;default&quot;  -- if argument x is false or nil, value becomes &quot;default&quot;
+  return value, x
+end
+
+return foo()
+-- Output: default
+
+return foo(1)
+-- Output: Collection(2) {1, 1}
+
+return foo(true)
+-- Output: Collection(2) {True, True}
+
+return foo(&quot;hello&quot;)
+-- Output: Collection(2) {hello, hello}
+</code></pre>
+<h3 id="ternary-operators">Ternary operators</h3>
+<p>Ternary operators [2] are a useful feature in C. e.g.</p>
+<pre><code class="language-c">int value = x &gt; 3 ? 1 : 0;
+</code></pre>
+<p>This behaviour can be partially emulated in Lua using the logical operators and and or. The C form:
+value = test ? x : y;
+roughly translates to the following Lua: value = test and x or y</p>
+<p>E.g.</p>
+<pre><code class="language-lua">3&gt;1 and 1 or 0
+-- Output: 1
+
+3&lt;1 and 1 or 0
+-- Output: 0
+
+3&lt;1 and &quot;True&quot; or &quot;False&quot; -- In RailCOMPLETE &quot;False&quot; is returned as false.
+-- Output: False
+
+3&gt;1 and true or &quot;false&quot;
+-- Output: True
+</code></pre>
+<p>This can be used for short hand to fill a hash:</p>
+<pre><code class="language-lua">t = {}
+t[1] = 12
+t[2] = 13
+for i=1, 3 do
+    t[i] = (t[i] or 0) + 1
+end
+
+text =&quot;&quot;
+for k, v in pairs(t) do
+    text = text..k..&quot;    &quot;..v..&quot;\n&quot;
+end
+
+return text
+
+--[[ 
+Output:  
+1    13
+2    14
+3    1
+--]]
+
+</code></pre>
+<p>However, there is a caveat: This only works when the first return value is not nil or false.</p>
+<pre><code class="language-lua">3&gt;1 and 1 or &quot;False&quot;         -- works
+
+-- Output: 1
+
+3&gt;1 and false or &quot;oops&quot;      -- failed, should return false
+
+-- Output: oops
+
+3&gt;1 and nil or &quot;oops&quot;        -- failed, should return nil
+
+-- Output: oops
+</code></pre>
+<p>Note on test expressions and nil</p>
+<p>An important point to note is that the value 0 is not a false test condition in Lua. In some languages, for example C, a test of:</p>
+<pre><code class="language-c">if (0)
+  printf(&quot;true&quot;);
+else
+  printf(&quot;false&quot;);
+</code></pre>
+<p>would display "false". In Lua,</p>
+<pre><code class="language-lua">if 0 then
+    return &quot;true&quot;
+else
+    return &quot;false&quot;
+end
+
+-- Output: true
+</code></pre>
+<p>prints "true"! You should use false, or nil in place of 0:</p>
+<pre><code class="language-lua">if false then return(&quot;true&quot;) else return(&quot;false&quot;) end
+
+-- Output: false
+
+if nil then return(&quot;true&quot;) else return(&quot;false&quot;) end
+
+-- Output: false
+</code></pre>
+<h2 id="control-structure-tutorial">Control Structure Tutorial</h2>
+<h3 id="if-statement"><em>if</em> statement</h3>
+<p>The <em>if</em> statement lets you run different code based on a condition:</p>
+<pre><code class="language-lua">if condition then
+  block
+elseif condition2 then
+  block
+elseif condition3 then
+  block
+else
+  block
+end
+</code></pre>
+<p>The <em>if</em> and <em>elseif</em> parts are checked in order, and once one of the conditions is true, it runs the block under it and skips to the end, ignoring any other <em>elseif</em> conditions after it. The <em>else</em> block is run if none of the conditions match. Finally, the elseif and <em>else</em> parts are optional.</p>
+<pre><code class="language-lua">n = 5
+if n &gt; 5 then return(&quot;greater than 5&quot;) else return(&quot;less than 5&quot;) end
+
+-- Output: less than 5
+
+n = 7
+if n &gt; 5 then return(&quot;greater than 5&quot;) else return(&quot;less than 5&quot;) end
+
+-- Output: greater than 5
+</code></pre>
+<p>A more complex example:</p>
+<pre><code class="language-lua">n = 12
+if n &gt; 15 then
+    return(&quot;the number is &gt; 15&quot;)
+elseif n &gt; 10 then
+    return(&quot;the number is &gt; 10&quot;)
+elseif n &gt; 5 then
+    return(&quot;the number is &gt; 5&quot;)
+else
+    return(&quot;the number is &lt;= 5&quot;)
+end
+
+-- Output: the number is &gt; 10
+
+</code></pre>
+<p>Notice how just one of the messages is returned, even though more than one of the conditions are true: This is because once one matches, the if statement skips checking the other conditions.</p>
+<h3 id="loops">Loops</h3>
+<h4 id="while-loop">While loop</h4>
+<pre><code class="language-lua">while condition do
+  block
+end
+</code></pre>
+<p>This runs the block over and over in a loop, but on each iteration, it first checks the condition, and if it's false, skips to the end, breaking the loop. If the condition is always false, the block will never be run.</p>
+<pre><code class="language-lua">text = &quot;&quot;
+i = 1
+while i &lt;= 10 do
+    text = text..i..&quot; &quot;
+    i = i + 1
+end
+
+return text
+
+-- Output: 1 2 3 4 5 6 7 8 9 10 
+</code></pre>
+<h4 id="repeat-loop">Repeat loop</h4>
+<pre><code class="language-lua">repeat
+  block
+until condition
+</code></pre>
+<p>Same as the while loop, except the condition is inverted (breaks the loop when true), and it's checked after the first iteration, so the code is guaranteed to run at least once.</p>
+<pre><code class="language-lua">text = &quot;&quot;
+i = 5
+repeat
+    text = text..i..&quot; &quot;
+    i = i - 1
+until i == 0
+
+return text
+
+-- Output: 5 4 3 2 1 
+</code></pre>
+<h4 id="numeric-for-loop">Numeric for loop</h4>
+<pre><code class="language-lua">for variable = start, stop, step do
+  block
+end
+</code></pre>
+<p>Runs the block with variable first being equal to start, then keeps incrementing it step amount and running the block again until it's greater than stop. step can be omitted and will default to 1.
+You can also make the step negative, and the loop will stop once the counter variable is less than the stop value.</p>
+<pre><code class="language-lua">text = &quot;&quot;
+for i = 1, 5 do
+    text = text..i..&quot; &quot;
+end
+
+return text
+
+-- Output: 1 2 3 4 5
+
+text = &quot;&quot;
+for i = 1, 100, 8 do
+    text = text..i..&quot; &quot;
+end
+
+return text
+
+-- Output: 1 9 17 25 33 41 49 57 65 73 81 89 97 
+
+text = &quot;&quot;
+for i = 0, 1, 0.25 do
+    text = text..i..&quot; &quot;
+end
+
+return text
+
+-- Output: 0 0.25 0.5 0.75 1
+
+text = &quot;&quot;
+for i = 1, 3 do
+    for j = 1, i do
+        text = text..j..&quot; &quot;
+    end
+end
+
+return text
+
+-- Output: 1 1 2 1 2 3 
+</code></pre>
+<h2 id="formulas">Formulas</h2>
+<p>Short Lua programs called <strong>formulas</strong> are used throughout RailCOMPLETE in various contexts. This section describes the various context and what RailCOMPLETE assumes about the formulas.</p>
+<h3 id="general">General</h3>
+<p>Formulas are typically evaluated in the context of a specific object, which means that the object's properties are available though variable names in the script. For example, the following formula applied to a railway object would evaluate to the concatenation of the object's name and code:</p>
+<pre><code class="language-lua">name .. code
+</code></pre>
+<p>The following formula would evaluate to true or false depending on the distance between the alignment and the object in question:</p>
+<pre><code class="language-lua">math.abs(DistanceToAlignment) &gt; 4.0
+</code></pre>
+<h3 id="filter-formula">Filter formula</h3>
+<p>Filters are formulas which are evaluated on each object in a a set of objects to filter the set.  For example, to select a set of objects to include in a table, a filter formula should return the <em>true</em> value when evaluated in the context of objects which are to be included in the set.</p>
+<p>The following formula includes main signals with the <em>home</em> function in the set:</p>
+<pre><code class="language-lua">RCType == &quot;Signal&quot; and type == &quot;main&quot; and function == &quot;home&quot;
+</code></pre>
+<h3 id="map-formula">Map formula</h3>
+<p>Maps are formulas which are evaulated on an object to return a representative value for the object. For example, to present a column in a table, a map formula corresponding to the column is evaluated for each object in the table, and the value which the formula evaluated to is inserted in the table cell. Note that if the formula fails to produce a value, a default value is used instead. For tables, the default value is blank. For route export, the default value is a question mark.</p>
+<p>The following formula presents the strings <em>near</em> or <em>far</em> depending on an objects distance from its alignment.</p>
+<pre><code class="language-lua">if math.abs(DistanceToAlignment) &gt; 6.0 then
+  return &quot;far&quot;
+else
+  return &quot;near&quot;
+end
+</code></pre>
+<h3 id="filter-map">Filter-map</h3>
+<p>Filter-map formulas perform the function of the filter and the map at the same time. If the formula evaluates to a value, then the object is included in the set and the mapped value is used as representative value for the object. If the formula does not evaluate to a value, then the object is not included in the set. Formulas can produce no value by not executing a <em>return</em> statement, by executing a <em>return</em> statement with no argument, or by executing a return statement using the <code>nil</code> value argument.</p>
+<p>The following formula presents all main signals by name:</p>
+<pre><code class="language-lua">if RCType == &quot;Signal&quot; and type == &quot;main&quot; then
+  return name
+end
+</code></pre>
+<p>The following formula is equivalent:</p>
+<pre><code class="language-lua">if RCType == &quot;Signal&quot; and type == &quot;main&quot; then
+  return name
+else
+  return nil
+end
+</code></pre>
+<h2 id="display-name-vs-property">Display Name VS Property</h2>
+<p>Some properties also have a display name. As shown below, the Model3DName property has a property display name 3D Model Name (in the properties window).</p>
+<p><img alt="Lua DisplayName" src="img/lua_displayname.png" /></p>
+<p>The value for Model3DName can also be found using the fromDisplayName function.</p>
+<pre><code class="language-lua">-- Using fromDisplayName to get Model3DName.
+fromDisplayName(&quot;3D Model Name&quot;)
+</code></pre>
+<p><img alt="Lua fromDisplayName" src="img/fromDisplayName.png" /></p>
+              
+            </div>
+          </div><footer>
+    <div class="rst-footer-buttons" role="navigation" aria-label="Footer Navigation">
+        <a href="060-export3d.html" class="btn btn-neutral float-left" title="Export 3D"><span class="icon icon-circle-arrow-left"></span> Previous</a>
+        <a href="080-luacommands.html" class="btn btn-neutral float-right" title="Lua Functions">Next <span class="icon icon-circle-arrow-right"></span></a>
+    </div>
+
+  <hr/>
+
+  <div role="contentinfo">
+    <!-- Copyright etc -->
+      <p>&copy Railcomplete AS, 2025</p>
+  </div>
+
+  Built with <a href="https://www.mkdocs.org/">MkDocs</a> using a <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+</footer>
+          
+        </div>
+      </div>
+
+    </section>
+
+  </div>
+
+  <div class="rst-versions" role="note" aria-label="Versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    
+    
+      <span><a href="060-export3d.html" style="color: #fcfcfc">&laquo; Previous</a></span>
+    
+    
+      <span><a href="080-luacommands.html" style="color: #fcfcfc">Next &raquo;</a></span>
+    
+  </span>
+</div>
+    <script src="js/jquery-3.6.0.min.js"></script>
+    <script>var base_url = ".";</script>
+    <script src="js/theme_extra.js"></script>
+    <script src="js/theme.js"></script>
+      <script src="search/main.js"></script>
+    <script>
+        jQuery(function () {
+            SphinxRtdTheme.Navigation.enable(true);
+        });
+    </script>
+
+</body>
+</html>

--- a/.claude/references/080-luacommands.html
+++ b/.claude/references/080-luacommands.html
@@ -1,0 +1,3170 @@
+<!DOCTYPE html>
+<html class="writer-html5" lang="en" >
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="author" content="Railcomplete AS" />
+      <link rel="shortcut icon" href="img/favicon.ico" />
+    <title>Lua Functions - RailCOMPLETE Reference Manual</title>
+    <link rel="stylesheet" href="css/theme.css" />
+    <link rel="stylesheet" href="css/theme_extra.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" />
+        <link href="extra.css" rel="stylesheet" />
+    
+      <script>
+        // Current page data
+        var mkdocs_page_name = "Lua Functions";
+        var mkdocs_page_input_path = "080-luacommands.md";
+        var mkdocs_page_url = null;
+      </script>
+    
+    <!--[if lt IE 9]>
+      <script src="js/html5shiv.min.js"></script>
+    <![endif]-->
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/lua.min.js"></script>
+      <script>hljs.highlightAll();</script> 
+</head>
+
+<body class="wy-body-for-nav" role="document">
+
+  <div class="wy-grid-for-nav">
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
+    <div class="wy-side-scroll">
+      <div class="wy-side-nav-search">
+<a href="./index.html" class="icon icon-home"> RailCOMPLETE Reference Manual</a><div role="search">
+  <form id ="rtd-search-form" class="wy-form" action="./search.html" method="get">
+      <input type="text" name="q" placeholder="Search docs" aria-label="Search docs" title="Type search term here" />
+  </form>
+</div>
+      </div>
+
+      <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
+    
+		<div style="display: inline-block;">
+												
+					
+					<a href="./080-luacommands.html">
+						<img style="height: 15px;" alt="English" src="./img/flags/en.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./fr/080-luacommands.html">
+						<img style="height: 15px;" alt="Français" src="./img/flags/fr.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./de/080-luacommands.html">
+						<img style="height: 15px;" alt="Deutsch" src="./img/flags/de.png" />
+					</a>
+					
+				
+
+			</div>
+		
+    
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="index.html">Welcome</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="010-gettingstarted.html">Getting started</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="020-mainfeatures.html">Main features</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="030-tipsandtricks.html">Tips and tricks</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="035-LinearReferencing.html">Linear Referencing</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="040-qa.html">Q&A</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="050-commands.html">RailCOMPLETE commands</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="060-export3d.html">Export 3D</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="070-lua.html">Lua</a>
+				</li>
+			</ul>
+			<ul class="current">
+				<li class="toctree-l1 current"><a class="reference internal current" href="080-luacommands.html">Lua Functions</a>
+    <ul class="current">
+    <li class="toctree-l2"><a class="reference internal" href="#common-lua-functions">Common Lua Functions</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#_info">_info()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#_luagetresult">_luaGetResult()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_1">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_1">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createexternallibraryobject">createExternalLibraryObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_2">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_2">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#filter">filter()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_3">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_3">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#finddetectionsectionintervals">findDetectionSectionIntervals()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_4">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_4">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#fromdisplayname">fromDisplayName()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_5">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_5">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#get3dblockimage">get3DBlockImage()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_6">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_6">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#get3dblockimagefamily">get3DBlockImageFamily()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_7">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_7">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getalignmentinfo">getAlignmentInfo()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_8">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_8">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getalignmentpos">getAlignmentPos()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_9">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_9">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getblockbounds">getBlockBounds()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_10">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_10">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getblockimage">getBlockImage()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_11">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_11">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getblocknames">getBlockNames()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_12">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_12">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getcollectionfromtable">getCollectionFromTable()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_13">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_13">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getcollectionlength">getCollectionLength()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_14">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_14">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getdistance">getDistance()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_15">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_15">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getdotnettype">getDotNetType()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_16">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_16">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getdownobject">getDownObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_17">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_17">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_1">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getdownobjectswithpaths">getDownObjectsWithPaths()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_18">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_18">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_2">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getenumdisplayname">getEnumDisplayName()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_19">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_19">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getexpandoobjectpropertynames">getExpandoObjectPropertyNames()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_20">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_20">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getfoulingpoints">getFoulingPoints()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_21">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_21">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getintersections">getIntersections()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_22">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_22">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_3">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getinvertedblockimage">getInvertedBlockImage()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_23">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_23">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getlinearaddress">getLinearAddress()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_24">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_24">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_4">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getluaformulastring">getLuaFormulaString()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_25">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_25">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getnearbyalignments">getNearbyAlignments()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_26">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_26">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getnearbypointobjects2d">getNearbyPointObjects2D()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_27">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_27">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getnearbypointobjects3d">getNearbyPointObjects3D()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_28">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_28">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getobjectfromid">getObjectFromId()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_29">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_29">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getobjectsfrompath">getObjectsFromPath()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_30">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_30">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getpathstodistancefrompos">getPathsToDistanceFromPos()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_31">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_31">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getpathstoobject">getPathsToObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_32">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_32">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getpoint3d">getPoint3D()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_33">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_33">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getpointobjectsinarea">getPointObjectsInArea()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_34">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_34">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getpropertyfromdisplayname">getPropertyFromDisplayName()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_35">Description:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getpropertyvalue">getPropertyValue()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_36">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_35">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getrailwayobjecttype">getRailwayObjectType()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_37">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_36">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getrelatedobjects">getRelatedObjects()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_38">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_37">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getschematicinput">getSchematicInput()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_39">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_38">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getstageinfo">getStageInfo()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_40">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_39">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getstepfromnextroundedmileage">getStepFromNextRoundedMileage()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_41">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_40">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getstepfromnextroundedreferencemileage">getStepFromNextRoundedReferenceMileage()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_42">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_41">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#gettablevalue">getTableValue()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_43">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_42">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getucsangle">getUcsAngle()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_44">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_43">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getunionofcollections">getUnionOfCollections()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_45">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_44">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_5">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getupobject">getUpObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_46">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_45">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_6">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getupobjectswithpaths">getUpObjectsWithPaths()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_47">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_46">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_7">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#geturldrive">getUrlDrive()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_48">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_47">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#geturldriveandfolder">getUrlDriveAndFolder()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_49">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_48">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#geturldriveandfolderandfilename">getUrlDriveAndFolderAndFilename()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_50">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_49">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#geturlextension">getUrlExtension()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_51">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_50">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#geturlfilename">getUrlFilename()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_52">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_51">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#geturlfilenameandextension">getUrlFilenameAndExtension()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_53">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_52">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#geturlfolder">getUrlFolder()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_54">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_53">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvariantnames">getVariantNames()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_55">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_54">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectorangle">getVectorAngle()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_56">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_55">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectoranglecossin">getVectorAngleCosSin()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_57">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_56">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectorangledd">getVectorAngleDD()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_58">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_57">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectorcrossproduct">getVectorCrossProduct()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_59">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_58">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectordifference">getVectorDifference()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_60">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_59">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectordotproduct">getVectorDotProduct()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_61">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_60">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectormodulus">getVectorModulus()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_62">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_61">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectornormalized">getVectorNormalized()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_63">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_62">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectorscalarproduct">getVectorScalarProduct()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_64">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_63">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getvectorsum">getVectorSum()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_65">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_64">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getversion">getVersion()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_66">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_65">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getxrefpath">getXrefPath()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_67">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_66">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getzeros">getZeros()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_68">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_67">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#includeluafile">includeLuaFile()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_69">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_68">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_8">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#isobjectreachablebypath">isObjectReachableByPath()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_70">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_69">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#isvisible">isVisible()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_71">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_70">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#orderbyascending">orderByAscending()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_72">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_71">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#orderbydescending">orderByDescending()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_73">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_72">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#prettyprintpath">prettyPrintPath()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_74">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_73">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#cadinterface">cadInterface</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#blockexist">blockExist()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getcadcolor">getCadColor()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getguid">getGUID()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getlatitudelongitudealtitudefromwcspoint">getLatitudeLongitudeAltitudeFromWcsPoint()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#gettextstyleid">getTextStyleId()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getwcspointfromlatitudelongitudealtitude">getWcsPointFromLatitudeLongitudeAltitude()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#isactivetogglecommand">isActiveToggleCommand()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#setgeolocationdata">setGeoLocationData()</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#deprecated">Deprecated</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#createobjectusingreflection">createObjectUsingReflection()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#distance">distance()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getclosestalignments">getClosestAlignments()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getclosesttracks">getClosestTracks()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getcollectionofrelatedobjects">getCollectionOfRelatedObjects()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#include">include()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#prop">prop()</a>
+    </li>
+        </ul>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#script-lua-functions">Script Lua Functions</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#addrepresentation3d">addRepresentation3D()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_90">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_88">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforalignment">askForAlignment()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_91">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_89">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_9">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askfordouble">askForDouble()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_92">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_90">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_10">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforfilename">askForFileName()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_93">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_91">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_11">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforfoldername">askForFolderName()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_94">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_92">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_12">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforinteger">askForInteger()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_95">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_93">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_13">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforkeyword">askForKeyword()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_96">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_94">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforobject">askForObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_97">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_95">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_14">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforpath">askForPath()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_98">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_96">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_15">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforpoint">askForPoint()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_99">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_97">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_16">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforpointobject">askForPointObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_100">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_98">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_17">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#askforstring">askForString()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_101">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_99">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_18">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#beginundobufferitem">beginUndoBufferItem()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_102">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_100">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#create3dpolyline">create3DPolyline()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_103">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_101">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createcantevent">createCantEvent()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_104">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_102">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createcantprofile">createCantProfile()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_105">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_103">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createclothoidsegment">createClothoidSegment()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_106">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_104">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_19">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createclothoidsegment2">createClothoidSegment2()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_107">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_105">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_20">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createclothoidsegmentfromneighbors">createClothoidSegmentFromNeighbors()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_108">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_106">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createcosinespiralsegment">createCosineSpiralSegment()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_109">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_107">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createcurvesegment">createCurveSegment()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_110">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_108">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_21">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createcurvesegment2">createCurveSegment2()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_111">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_109">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createcurvesegment3">createCurveSegment3()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_112">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_110">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createhorizontalgeometry">createHorizontalGeometry()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_113">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_111">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_22">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createlinesegment">createLineSegment()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_114">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_112">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_23">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createmileageevent">createMileageEvent()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_115">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_113">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createmileageprofile">createMileageProfile()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_116">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_114">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createspeedevent">createSpeedEvent()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_117">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_115">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createspeedprofile">createSpeedProfile()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_118">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_116">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createverticalevent">createVerticalEvent()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_119">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_117">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#createverticalprofile">createVerticalProfile()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_120">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_118">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#deserializejson">deserializeJson()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_121">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_119">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#deserializexml">deserializeXml()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_122">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_120">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#endundobufferitem">endUndoBufferItem()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_123">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_121">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#eraseobject">eraseObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_124">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_122">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#exportstringtofile">exportStringToFile()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_125">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_123">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#exporttoifc">exportToIfc()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_126">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_124">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#exporttojson">exportToJson()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_127">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_125">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#exporttoxml">exportToXml()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_128">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_126">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#generateguid">generateGuid()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_129">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_127">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getfilefrompath">getFileFromPath()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_130">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_128">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getfilefromprompt">getFileFromPrompt()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_131">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_129">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getfilesinfolder">getFilesInFolder()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_132">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_130">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getfoldersinfolder">getFoldersInFolder()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_133">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_131">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#getstartangleforarc">getStartAngleForArc()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_134">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_132">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#insertalignment">insertAlignment()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_135">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_133">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_24">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#insertalignmentfromrailwaypath">insertAlignmentFromRailwayPath()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_136">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_134">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_25">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#insertpointobject">insertPointObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_137">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_135">Method Signatures:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#example_26">Example:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#movepointobject">movePointObject()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_138">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_136">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#runcommand">runCommand()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_139">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_137">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#runexternallibraryfunction">runExternalLibraryFunction()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_140">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_138">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#setpointobjectdisplayoffset">setPointObjectDisplayOffset()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_141">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_139">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#setpointobjectdisplaypoint">setPointObjectDisplayPoint()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_142">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_140">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#setrcid">setRcId()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_143">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_141">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#setrelation">setRelation()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_144">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_142">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#setselectionset">setSelectionSet()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_145">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_143">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#settextattribute">setTextAttribute()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_146">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_144">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#settextpositionformula">setTextPositionFormula()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_147">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_145">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#settextrotationformula">setTextRotationFormula()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_148">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_146">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#showmessage">showMessage()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_149">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_147">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#updatealignmenthorizontaldata">updateAlignmentHorizontalData()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_150">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_148">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#updatealignmentverticaldata">updateAlignmentVerticalData()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_151">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_149">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#write">write()</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#description_152">Description:</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#method-signatures_150">Method Signatures:</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#cadinterface_1">cadInterface</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#addentitiestoblock">addEntitiesToBlock()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#addentitiestomodelspace">addEntitiesToModelSpace()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#addlayers">addLayers()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#createblock">createBlock()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#createcadentity">createCadEntity()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#explodeentity">explodeEntity()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getblockreference">getBlockReference()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getclonesofnontextentitiesinblock">getClonesOfNonTextEntitiesInBlock()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getinnerblockreference">getInnerBlockReference()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getobjectsfromcadcollection">getObjectsFromCadCollection()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getpolyline">getPolyline()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#loadlinetype">loadLineType()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#runentitymethodswithtransaction">runEntityMethodsWithTransaction()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#setentitypropertieswithtransaction">setEntityPropertiesWithTransaction()</a>
+    </li>
+        </ul>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#deprecated_1">Deprecated</a>
+        <ul>
+    <li class="toctree-l4"><a class="reference internal" href="#createalignmentobject">createAlignmentObject()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#createhorizontalprofile">createHorizontalProfile()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#createpointobject">createPointObject()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getcontentsfromfile">getContentsFromFile()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#getguid_1">getGUID()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#runstaticmethodusingreflection">runStaticMethodUsingReflection()</a>
+    </li>
+    <li class="toctree-l4"><a class="reference internal" href="#setobjectid">setObjectId()</a>
+    </li>
+        </ul>
+    </li>
+        </ul>
+    </li>
+    </ul>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="080-luadebugger.html">Lua debugger</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="090-classdiagrams.html">Class Diagrams</a>
+				</li>
+			</ul>
+      </div>
+    </div>
+    </nav>
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+      <nav class="wy-nav-top" role="navigation" aria-label="Mobile navigation menu">
+          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+          <a href="index.html">RailCOMPLETE Reference Manual</a>
+        
+      </nav>
+      <div class="wy-nav-content">
+        <div class="rst-content"><div role="navigation" aria-label="breadcrumbs navigation">
+  <ul class="wy-breadcrumbs">
+    <li><a href="index.html" class="icon icon-home" aria-label="Docs"></a></li>
+      <li class="breadcrumb-item active">Lua Functions</li>
+    <li class="wy-breadcrumbs-aside">
+    </li>
+  </ul>
+  <hr/>
+</div>
+          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+            <div class="section" itemprop="articleBody">
+              
+                <h1 id="lua-functions">Lua Functions</h1>
+<h2 id="common-lua-functions">Common Lua Functions</h2>
+<h4 id="_info">_info()</h4>
+<h5 id="description">Description:</h5>
+<p>Set a tooltip message on the LuaExpression.
+Tooltip will be shown in Manage Properties when hovering over formula icon for property.
+Only applicable when editing formulas for properties.</p>
+<h5 id="method-signatures">Method Signatures:</h5>
+<pre><code class="language-lua">_info(String message)
+</code></pre>
+<p>Returns <code>TooltipMessage</code>.</p>
+<h4 id="_luagetresult">_luaGetResult()</h4>
+<h5 id="description_1">Description:</h5>
+<p>Returns the Values of each object.</p>
+<h5 id="method-signatures_1">Method Signatures:</h5>
+<pre><code class="language-lua">_luaGetResult(Object objects...)
+</code></pre>
+<p>Returns <code>Collection&lt;object&gt;, number Count</code>.</p>
+<h4 id="createexternallibraryobject">createExternalLibraryObject()</h4>
+<h5 id="description_2">Description:</h5>
+<p>Creates instance of an object using reflection.</p>
+<h5 id="method-signatures_2">Method Signatures:</h5>
+<pre><code class="language-lua">createExternalLibraryObject(String name, Collection args, Table initializePropertyDictionary)
+</code></pre>
+<p>Returns <code>object</code>.</p>
+<h4 id="filter">filter()</h4>
+<h5 id="description_3">Description:</h5>
+<p>Filters a collection with a given function. Objects pass the filter if the given function returns anything other than false or nil.</p>
+<h5 id="method-signatures_3">Method Signatures:</h5>
+<pre><code class="language-lua">filter(IEnumerable collection, LuaFunction function)
+filter(this IEnumerable collection:, LuaFunction function)
+</code></pre>
+<p>Returns <code>Collection&lt;Reference&gt;, number Count</code>.</p>
+<h4 id="finddetectionsectionintervals">findDetectionSectionIntervals()</h4>
+<h5 id="description_4">Description:</h5>
+<p>Returns detection section intervals.</p>
+<h5 id="method-signatures_4">Method Signatures:</h5>
+<pre><code class="language-lua">findDetectionSectionIntervals()
+</code></pre>
+<p>Returns <code>IEnumerable&lt;Tuple&lt;(string, Reference), IEnumerable&lt;AlignmentInterval&gt;&gt;&gt;</code>.</p>
+<h4 id="fromdisplayname">fromDisplayName()</h4>
+<h5 id="description_5">Description:</h5>
+<p>For a given object, gets value of property with given display name.</p>
+<h5 id="method-signatures_5">Method Signatures:</h5>
+<pre><code class="language-lua">fromDisplayName(this IBaseObject baseObject:, String displayName)
+</code></pre>
+<p>Returns <code>Object</code>.</p>
+<h4 id="get3dblockimage">get3DBlockImage()</h4>
+<h5 id="description_6">Description:</h5>
+<p>Returns a 3D image of the object's 3D geometry. Numpad positions 1..9 represent the observer, the object being in the middle.</p>
+<h5 id="method-signatures_6">Method Signatures:</h5>
+<pre><code class="language-lua">get3DBlockImage()
+get3DBlockImage(this reference:)
+get3DBlockImage(Int viewDirection, Boolean crop = false)
+get3DBlockImage(Int viewDirection, Int width, Boolean crop = false)
+get3DBlockImage(Int viewDirection, Int width, String style, Boolean crop = false)
+</code></pre>
+<p>Returns <code>ImageSource</code>.</p>
+<h4 id="get3dblockimagefamily">get3DBlockImageFamily()</h4>
+<h5 id="description_7">Description:</h5>
+<p>Returns a 3D image of the object's family tree.
+This function utilizes the 3D configuration stored in the document.</p>
+<h5 id="method-signatures_7">Method Signatures:</h5>
+<pre><code class="language-lua">get3DBlockImageFamily()
+get3DBlockImageFamily(this reference:)
+get3DBlockImageFamily(Int viewDirection, Boolean crop = false)
+get3DBlockImageFamily(Int viewDirection, Int width, Boolean crop = false)
+get3DBlockImageFamily(Int viewDirection, Int width, String style, Boolean crop = false)
+</code></pre>
+<p>Returns <code>ImageSource</code>.</p>
+<h4 id="getalignmentinfo">getAlignmentInfo()</h4>
+<h5 id="description_8">Description:</h5>
+<p>Returns alignment information at the position of the object.</p>
+<h5 id="method-signatures_8">Method Signatures:</h5>
+<pre><code class="language-lua">getAlignmentInfo()
+getAlignmentInfo(this reference:)
+getAlignmentInfo(String alignmentID)
+getAlignmentInfo(String alignmentID, Double x, Double y)
+getAlignmentInfo(String alignmentID, Point3D point)
+getAlignmentInfo(String alignmentID, Double distanceAlong)
+getAlignmentInfo(this reference:, Point3D point)
+getAlignmentInfo(AlignmentPos alignmentPosition)
+getAlignmentInfo(RailwayPath path, Double x, Double y)
+getAlignmentInfo(RailwayPath path, Point3D point)
+getAlignmentInfo(RailwayPath path, Double distanceAlong)
+</code></pre>
+<p>Returns <code>AlignmentInfoValues</code>.</p>
+<h4 id="getalignmentpos">getAlignmentPos()</h4>
+<h5 id="description_9">Description:</h5>
+<p>Returns an AlignmentPos for the given alignment at the given position.</p>
+<h5 id="method-signatures_9">Method Signatures:</h5>
+<pre><code class="language-lua">getAlignmentPos(this reference:)
+getAlignmentPos(this reference:, Double distanceAlong)
+getAlignmentPos(String alignmentID, Double distanceAlong)
+getAlignmentPos(this RailwayPath path:, Double distanceAlong)
+</code></pre>
+<p>Returns <code>AlignmentPos</code>.</p>
+<h4 id="getblockbounds">getBlockBounds()</h4>
+<h5 id="description_10">Description:</h5>
+<p>Get Bounds of block with given name</p>
+<h5 id="method-signatures_10">Method Signatures:</h5>
+<pre><code class="language-lua">getBlockBounds(String name)
+</code></pre>
+<p>Returns <code>object</code>.</p>
+<h4 id="getblockimage">getBlockImage()</h4>
+<h5 id="description_11">Description:</h5>
+<p>Returns an image of the object's symbol block.</p>
+<h5 id="method-signatures_11">Method Signatures:</h5>
+<pre><code class="language-lua">getBlockImage()
+getBlockImage(this IBaseObject railwayObject:)
+getBlockImage(Double width, Double height, Boolean crop = false, Boolean useActualSymbol = false)
+getBlockImage(this IBaseObject railwayObject:, Double width, Double height, Boolean crop = false, Boolean useActualSymbol = false, Boolean dilate = false, int dilateMatrixSize = 5)
+</code></pre>
+<p>Returns <code>ImageSource</code>.</p>
+<h4 id="getblocknames">getBlockNames()</h4>
+<h5 id="description_12">Description:</h5>
+<p>Returns the names of object's symbol blocks.</p>
+<h5 id="method-signatures_12">Method Signatures:</h5>
+<pre><code class="language-lua">getBlockNames()
+getBlockNames(this placedObjectBase:)
+</code></pre>
+<p>Returns <code>Collection&lt;String&gt;, number Count</code>.</p>
+<h4 id="getcollectionfromtable">getCollectionFromTable()</h4>
+<h5 id="description_13">Description:</h5>
+<p>Creates a collection from a Lua table.</p>
+<h5 id="method-signatures_13">Method Signatures:</h5>
+<pre><code class="language-lua">getCollectionFromTable(LuaTable luaTable)
+</code></pre>
+<p>Returns <code>Collection&lt;Object&gt;, number Count</code>.</p>
+<h4 id="getcollectionlength">getCollectionLength()</h4>
+<h5 id="description_14">Description:</h5>
+<p>Returns the length of a collection or 0 if collection is null.</p>
+<h5 id="method-signatures_14">Method Signatures:</h5>
+<pre><code class="language-lua">getCollectionLength(IEnumerable collection)
+getCollectionLength(this IEnumerable collection:)
+</code></pre>
+<p>Returns <code>Int</code>.</p>
+<h4 id="getdistance">getDistance()</h4>
+<h5 id="description_15">Description:</h5>
+<p>Calculates distance-along-path.</p>
+<p>This is the distance measured along the XY plane geometry of the shortest path from the source object's projection onto its own alignment to the target object's projection onto its own alignment. If no such path exists then 'NaN' is returned. 
+The Z coordinate and the effect of cant are disregarded if the alignments are 3D railway tracks with cant.</p>
+<h5 id="method-signatures_15">Method Signatures:</h5>
+<pre><code class="language-lua">getDistance(IPlacedObjectBase ToObject)
+getDistance(this IPlacedObjectBase FromObject:, IPlacedObjectBase ToObject)
+getDistance(AlignmentPos ToAlignmentPos)
+getDistance(IPlacedObjectBase FromObject, AlignmentPos ToAlignmentPos)
+getDistance(AlignmentPos FromAlignmentPos, AlignmentPos ToAlignmentPos)
+</code></pre>
+<p>Returns <code>Double</code>.</p>
+<h5 id="example">Example:</h5>
+<pre><code class="language-lua">--Example must be run in scrip context
+local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment(p2, d1, l1, 0, math.sqrt(l1*r), true)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+local alignmentVariant = &quot;Enkle skinner og sviller&quot; --NO-BN basic track variant
+local alignment = createAlignmentObject(rctype_Track, alignmentVariant, horizontalGeometry)
+
+local signalVariant = &quot;ERTMS E35 Stoppskilt, sidestilt&quot; --NO-BN ERTMS stop sign insertion option name
+local signal1 = createPointObject(alignment, rctype_EtcsEoA, signalVariant, 600, 4, false)
+local signal2 = createPointObject(alignment, rctype_EtcsEoA, signalVariant, 200, 4, false)
+
+local distance = getDistance(signal1, signal2)
+write(distance)
+</code></pre>
+<h4 id="getdotnettype">getDotNetType()</h4>
+<h5 id="description_16">Description:</h5>
+<p>Returns the.Net type of an object or uses reflection to get type if type name is given as a string e.g. 'System.Double'</p>
+<h5 id="method-signatures_16">Method Signatures:</h5>
+<pre><code class="language-lua">getDotNetType(object obj)
+getDotNetType(string typeName)
+</code></pre>
+<p>Returns <code>Type</code>.</p>
+<h4 id="getdownobject">getDownObject()</h4>
+<h5 id="description_17">Description:</h5>
+<p>Searches in the down direction and returns the next object along the search's path.
+ - The search starts at the given IBaseObject or AlignmentPos.
+ - If an rcType is specified then the search skips objects of other types.
+ - If searchInvisible is false then the search skips objects on invisible layers.</p>
+<h5 id="method-signatures_17">Method Signatures:</h5>
+<pre><code class="language-lua">getDownObject(this IBaseObject sourceObject, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getDownObject(AlignmentPos sourceAlignmentPos, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getDownObject(this IBaseObject sourceObject, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getDownObject(AlignmentPos sourceAlignmentPos, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+</code></pre>
+<p>Returns <code>IBaseObject</code>.</p>
+<h5 id="example_1">Example:</h5>
+<pre><code class="language-lua">getDownObject(this, rctype_Signal) -- This example can be called from a placed object.
+</code></pre>
+<h4 id="getdownobjectswithpaths">getDownObjectsWithPaths()</h4>
+<h5 id="description_18">Description:</h5>
+<p>Searches in the down direction and returns a list of tuples (object, path to object). For each path in the down direction the function searches for the first object it encounters along that path and returns the tuple (object, path to object).
+ - The search starts at the given IBaseObject or AlignmentPos.
+ - If an rcType is specified then the search skips objects of other types.</p>
+<p>The returned tuples are ordered by ascending path lengths.</p>
+<h5 id="method-signatures_18">Method Signatures:</h5>
+<pre><code class="language-lua">getDownObjectsWithPaths(IBaseObject sourceObject = this, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getDownObjectsWithPaths(AlignmentPos sourceAlignmentPos, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getDownObjectsWithPaths(IBaseObject sourceObject = this, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getDownObjectsWithPaths(AlignmentPos sourceAlignmentPos, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+</code></pre>
+<p>Returns <code>Collection&lt;ObjectAndPath&gt;, number Count</code>.</p>
+<h5 id="example_2">Example:</h5>
+<pre><code class="language-lua">getDownObjectsWithPaths(this, rctype_Signal) -- This example can be called from a placed object.
+</code></pre>
+<h4 id="getenumdisplayname">getEnumDisplayName()</h4>
+<h5 id="description_19">Description:</h5>
+<p>Returns the display name of an enumeration value of the property.
+If the enumeration value does not have a display name, returns the value. If the property value is not an enumeration value, returns nil.</p>
+<h5 id="method-signatures_19">Method Signatures:</h5>
+<pre><code class="language-lua">getEnumDisplayName(String propertyName)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="getexpandoobjectpropertynames">getExpandoObjectPropertyNames()</h4>
+<h5 id="description_20">Description:</h5>
+<p>Get a list of the property names of the dynamic object.</p>
+<h5 id="method-signatures_20">Method Signatures:</h5>
+<pre><code class="language-lua">getExpandoObjectPropertyNames(this expandoObject:)
+</code></pre>
+<p>Returns <code>Collection&lt;string&gt;, number Count</code>.</p>
+<h4 id="getfoulingpoints">getFoulingPoints()</h4>
+<h5 id="description_21">Description:</h5>
+<p>Calculates the fouling points for the current switch.</p>
+<p>Access the available foulingPointSettingNames through the FoulingPointSettings global variable.</p>
+<p>If a fouling point setting name is provided then this function uses that setting or returns nil if it can't be found. Otherwise it uses a default fouling point setting from DNA.</p>
+<p>The real elevation of the ground at the fouling point it not known so it is taken to be the average of the two branch point elevations.</p>
+<p>Returned FoulingPointResults are ordered by ascending ClearanceDistance, i.e. the 2D Euclidean distance from the switch insertion point to the relevant fouling point.</p>
+<h5 id="method-signatures_21">Method Signatures:</h5>
+<pre><code class="language-lua">getFoulingPoints()
+getFoulingPoints(this reference:)
+getFoulingPoints(String foulingPointSettingName)
+getFoulingPoints(this reference:, String foulingPointSettingName)
+</code></pre>
+<p>Returns <code>Collection&lt;FoulingPointResult&gt;, number Count</code>.</p>
+<h4 id="getintersections">getIntersections()</h4>
+<h5 id="description_22">Description:</h5>
+<p>Intersects an alignment with a polyline, returning the distance along values of the intersections on the alignment.</p>
+<h5 id="method-signatures_22">Method Signatures:</h5>
+<pre><code class="language-lua">getIntersections(this IAlignment alignment:, Collection&lt;Point3D&gt; polyline)
+</code></pre>
+<p>Returns <code>Collection&lt;Double&gt;, number Count</code>.</p>
+<h5 id="example_3">Example:</h5>
+<pre><code class="language-lua">local intersectionDistanceAlongValues, count = alignment:getIntersections({getPoint3D(0,0,0), getPoint3D(5,0,0)})
+</code></pre>
+<h4 id="getinvertedblockimage">getInvertedBlockImage()</h4>
+<h5 id="description_23">Description:</h5>
+<p>Returns an inverted image of the object's symbol block.</p>
+<h5 id="method-signatures_23">Method Signatures:</h5>
+<pre><code class="language-lua">getInvertedBlockImage()
+getInvertedBlockImage(this reference:)
+getInvertedBlockImage(Double width, Boolean crop = false, Boolean useActualSymbol = false)
+getInvertedBlockImage(this reference:, Double width, Boolean crop = false, Boolean useActualSymbol = false, Boolean dilate = false, int dilateMatrixSize = 5)
+</code></pre>
+<p>Returns <code>ImageSource</code>.</p>
+<h4 id="getlinearaddress">getLinearAddress()</h4>
+<h5 id="description_24">Description:</h5>
+<p>Get a linear address, i.e. a 3d position relative to an alignment.
+This function needs a point and an alignment.The point can be expressed by:
+ - a Point3D,
+ - an object,
+ - an object id or
+ - the current object (this).
+The alignment can be expressed by
+ - an alignment object,
+ - an alignment id,
+ - the provided point object's own alignment or
+ - an alignment RcType, the closest of which will be used.</p>
+<h5 id="method-signatures_24">Method Signatures:</h5>
+<pre><code class="language-lua">getLinearAddress(this IBaseObject pointObject:)
+getLinearAddress(string objectId)
+getLinearAddress(Point3D point, IAlignment alignment) --See description
+getLinearAddress(LuaTable point, IAlignment alignment) --See description
+</code></pre>
+<p>Returns <code>LinearAddress, LuaFunctionResult</code>.</p>
+<h5 id="example_4">Example:</h5>
+<pre><code class="language-lua">--Example must be run in scrip context
+local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692) 
+local p3 = getPoint3D(671.898, 550.8322) 
+local p4 = getPoint3D(844.4075, 637.7367) 
+local p5 = getPoint3D(877.9371, 659.5475) 
+local d1 = math.deg(0.349924146) 
+local d2 = math.deg(0.369924153) 
+local l1 = 40 
+local l2 = 193.4645 
+local r = 1000  
+local line = createLineSegment(p1, p2) 
+local clothoid = createClothoidSegment(p2, d1, l1, 0, math.sqrt(l1*r), true) 
+local curve = createCurveSegment(p3, d2, l2, r)  
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve}) local alignmentVariant = &quot;Enkle skinner og sviller&quot; --NO-BN basic track variant 
+local alignment = createAlignmentObject(rctype_Track, alignmentVariant, horizontalGeometry)  
+local signalVariant = &quot;ERTMS E35 Stoppskilt, sidestilt&quot; --NO-BN ERTMS stop sign insertion option name 
+local signal = createPointObject(alignment, rctype_EtcsEoA, signalVariant, 600, 4, false) 
+
+
+local linearAddress = getLinearAddress(signal, alignment)
+write(linearAddress)
+</code></pre>
+<h4 id="getluaformulastring">getLuaFormulaString()</h4>
+<h5 id="description_25">Description:</h5>
+<p>Returns the Lua formula of a property.</p>
+<h5 id="method-signatures_25">Method Signatures:</h5>
+<pre><code class="language-lua">getLuaFormulaString(String propertyName)
+getLuaFormulaString(this reference:, String propertyName)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="getnearbyalignments">getNearbyAlignments()</h4>
+<h5 id="description_26">Description:</h5>
+<p>Returns all alignments sorted by proximity to object or point. Optionally only return alignments within a given distance of the object or point.</p>
+<h5 id="method-signatures_26">Method Signatures:</h5>
+<pre><code class="language-lua">getNearbyAlignments(Point3D point, String rcType = nil, double distance = inf, Boolean searchInvisible = false)
+getNearbyAlignments(this reference:, String rcType = nil, double distance = inf, Boolean searchInvisible = false)
+getNearbyAlignments(String rcType = nil, double distance = inf, Boolean searchInvisible = false)
+</code></pre>
+<p>Returns <code>Collection&lt;IAlignment&gt;, number Count</code>.</p>
+<h4 id="getnearbypointobjects2d">getNearbyPointObjects2D()</h4>
+<h5 id="description_27">Description:</h5>
+<p>Returns all point objects located within a given 2D distance from the object (or point if a point is used as an argument).
+Returned objects are sorted by proximity.</p>
+<h5 id="method-signatures_27">Method Signatures:</h5>
+<pre><code class="language-lua">getNearbyPointObjects2D(Point3D point, Double distance = 1.0)
+getNearbyPointObjects2D(Point3D point, IEnumerable&lt;IBaseObject&gt; filteredObjects, Double distance = 1.0)
+getNearbyPointObjects2D(String rcType, Point3D point, Double distance = 1.0)
+getNearbyPointObjects2D(String rcType, Boolean searchInvisible, Point3D point, Double distance = 1.0)
+getNearbyPointObjects2D(this reference:, Double distance = 1.0)
+getNearbyPointObjects2D(this reference:, String rcType, Double distance = 1.0)
+getNearbyPointObjects2D(this reference:, String rcType, Boolean searchInvisible, Double distance = 1.0)
+getNearbyPointObjects2D(RailwayPath path, Double distance = 1.0)
+getNearbyPointObjects2D(RailwayPath path, String rcType, Double distance = 1.0)
+getNearbyPointObjects2D(RailwayPath path, String rcType, Boolean searchInvisible, Double distance = 1.0)
+</code></pre>
+<p>Returns <code>Collection&lt;IBaseObject&gt;, number Count</code>.</p>
+<h4 id="getnearbypointobjects3d">getNearbyPointObjects3D()</h4>
+<h5 id="description_28">Description:</h5>
+<p>Returns all point objects located within a given 3D distance from the object (or point if a point is used as an argument).
+Returned objects are sorted by proximity.</p>
+<h5 id="method-signatures_28">Method Signatures:</h5>
+<pre><code class="language-lua">getNearbyPointObjects3D(Point3D point, Double distance = 1.0)
+getNearbyPointObjects3D(Point3D point, Collection&lt;IBaseObject&gt; filteredObjects, Double distance = 1.0)
+getNearbyPointObjects3D(String rcType, Point3D point, Double distance = 1.0)
+getNearbyPointObjects3D(String rcType, Boolean searchInvisible, Point3D point, Double distance = 1.0)
+getNearbyPointObjects3D(this reference:, Double distance = 1.0)
+getNearbyPointObjects3D(this reference:, String rcType, Double distance = 1.0)
+getNearbyPointObjects3D(this reference:, String rcType, Boolean searchInvisible, Double distance = 1.0)
+getNearbyPointObjects3D(RailwayPath path, Double distance = 1.0)
+getNearbyPointObjects3D(RailwayPath path, String rcType, Double distance = 1.0)
+getNearbyPointObjects3D(RailwayPath path, String rcType, Boolean searchInvisible, Double distance = 1.0)
+</code></pre>
+<p>Returns <code>Collection&lt;IBaseObject&gt;, number Count</code>.</p>
+<h4 id="getobjectfromid">getObjectFromId()</h4>
+<h5 id="description_29">Description:</h5>
+<p>Returns the railway object with the given ID.</p>
+<h5 id="method-signatures_29">Method Signatures:</h5>
+<pre><code class="language-lua">getObjectFromId(String id)
+</code></pre>
+<p>Returns <code>IBaseObject</code>.</p>
+<h4 id="getobjectsfrompath">getObjectsFromPath()</h4>
+<h5 id="description_30">Description:</h5>
+<p>Returns all objects on a given path.
+If one or more object types are specified, returns only objects of those types.</p>
+<h5 id="method-signatures_30">Method Signatures:</h5>
+<pre><code class="language-lua">getObjectsFromPath(RailwayPath path, Boolean searchInvisible = false, String rcTypes...)
+</code></pre>
+<p>Returns <code>Collection&lt;IBaseObject&gt;, number Count</code>.</p>
+<h4 id="getpathstodistancefrompos">getPathsToDistanceFromPos()</h4>
+<h5 id="description_31">Description:</h5>
+<p>Returns all paths from a position to a specified distance.
+The position is a 'pos' on a given alignment. The search direction can be specified ('up 'or 'down').</p>
+<h5 id="method-signatures_31">Method Signatures:</h5>
+<pre><code class="language-lua">getPathsToDistanceFromPos(AlignmentPos alignmentPos, String direction = &quot;up&quot;, Double distance)
+</code></pre>
+<p>Returns <code>Collection&lt;RailwayPath&gt;, number Count</code>.</p>
+<h4 id="getpathstoobject">getPathsToObject()</h4>
+<h5 id="description_32">Description:</h5>
+<p>Returns a list of all paths from this object to another.</p>
+<h5 id="method-signatures_32">Method Signatures:</h5>
+<pre><code class="language-lua">getPathsToObject(this IBaseObject sourceObject:, String targetObjectId, Boolean searchInvisible = false)
+getPathsToObject(AlignmentPos sourceAlignmentPos, String targetObjectId, Boolean searchInvisible = false)
+</code></pre>
+<p>Returns <code>Collection&lt;RailwayPath&gt;, number Count</code>.</p>
+<h4 id="getpoint3d">getPoint3D()</h4>
+<h5 id="description_33">Description:</h5>
+<p>Returns a Point3D.</p>
+<h5 id="method-signatures_33">Method Signatures:</h5>
+<pre><code class="language-lua">getPoint3D(Reference ref = this)
+getPoint3D(Double x, Double y, Double z = 0)
+getPoint3D(LinearAddress linearAddress)
+</code></pre>
+<p>Returns <code>Point3D</code>.</p>
+<h4 id="getpointobjectsinarea">getPointObjectsInArea()</h4>
+<h5 id="description_34">Description:</h5>
+<p>Returns point objects in area.</p>
+<h5 id="method-signatures_34">Method Signatures:</h5>
+<pre><code class="language-lua">getPointObjectsInArea(this IArea area:)
+getPointObjectsInArea(this IArea area:, Boolean searchVisible)
+</code></pre>
+<p>Returns <code>Collection&lt;IBaseObject&gt;, number Count</code>.</p>
+<h4 id="getpropertyfromdisplayname">getPropertyFromDisplayName()</h4>
+<h5 id="description_35">Description:</h5>
+<p>Returns property from display name.</p>
+<h4 id="getpropertyvalue">getPropertyValue()</h4>
+<h5 id="description_36">Description:</h5>
+<p>Returns the value of the property without executing formula in property.</p>
+<h5 id="method-signatures_35">Method Signatures:</h5>
+<pre><code class="language-lua">getPropertyValue(String propertyName)
+</code></pre>
+<p>Returns <code>Object</code>.</p>
+<h4 id="getrailwayobjecttype">getRailwayObjectType()</h4>
+<h5 id="description_37">Description:</h5>
+<p>Get the object type definition from the current DNA given the type name</p>
+<h5 id="method-signatures_36">Method Signatures:</h5>
+<pre><code class="language-lua">getRailwayObjectType(String name)
+</code></pre>
+<p>Returns <code>RailwayObjectType</code>.</p>
+<h4 id="getrelatedobjects">getRelatedObjects()</h4>
+<h5 id="description_38">Description:</h5>
+<p>Returns a collection of objects connected through the specified relation, and the number of related objects found. Source object and visibility are optional arguments.</p>
+<h5 id="method-signatures_37">Method Signatures:</h5>
+<pre><code class="language-lua">getRelatedObjects(String relationName, IBaseObject sourceObject = this, Boolean Invisible = false)
+</code></pre>
+<p>Returns <code>Collection&lt;IBaseObject&gt;, number Count</code>.</p>
+<h4 id="getschematicinput">getSchematicInput()</h4>
+<h5 id="description_39">Description:</h5>
+<p>Returns detection section intervals.</p>
+<h5 id="method-signatures_38">Method Signatures:</h5>
+<pre><code class="language-lua">getSchematicInput(Collection trackIds, Collection objectIds)
+</code></pre>
+<p>Returns <code>IEnumerable&lt;Tuple&lt;string, IEnumerable&lt;AlignmentInterval&gt;&gt;&gt;</code>.</p>
+<h4 id="getstageinfo">getStageInfo()</h4>
+<h5 id="description_40">Description:</h5>
+<p>Returns StageInfo, a collection of information about stages. It includes which stages are currently enabled/selected as entering/current/leaving.</p>
+<p>Note that if layers have been updated without using the Stage Manager, then there may be a mismatch between provided stages and enabled layers.</p>
+<p>See the Stage Manager from for more details about stages.</p>
+<h5 id="method-signatures_39">Method Signatures:</h5>
+<pre><code class="language-lua">getStageInfo()
+</code></pre>
+<p>Returns <code>ReturnType</code>.</p>
+<h4 id="getstepfromnextroundedmileage">getStepFromNextRoundedMileage()</h4>
+<h5 id="description_41">Description:</h5>
+<p>Obtains the distance to the next DistanceAlong where Mileage is divisible by MileageStepLength.</p>
+<h5 id="method-signatures_40">Method Signatures:</h5>
+<pre><code class="language-lua">getStepFromNextRoundedMileage(this IAlignment alignment:, double mileageStepLength, double distanceAlong)
+</code></pre>
+<p>Returns <code>ReturnType</code>.</p>
+<h4 id="getstepfromnextroundedreferencemileage">getStepFromNextRoundedReferenceMileage()</h4>
+<h5 id="description_42">Description:</h5>
+<p>Obtains the distance to the next DistanceAlong where ReferenceMileage is divisible by referenceMileageStepLength.</p>
+<h5 id="method-signatures_41">Method Signatures:</h5>
+<pre><code class="language-lua">getStepFromNextRoundedReferenceMileage(this IAlignment alignment:, double referenceMileageStepLength, double distanceAlong)
+</code></pre>
+<p>Returns <code>ReturnType</code>.</p>
+<h4 id="gettablevalue">getTableValue()</h4>
+<h5 id="description_43">Description:</h5>
+<p>Returns the value stored in a LuaTable.</p>
+<h5 id="method-signatures_42">Method Signatures:</h5>
+<pre><code class="language-lua">getTableValue(LuaTable table)
+</code></pre>
+<p>Returns <code>Object</code>.</p>
+<h4 id="getucsangle">getUcsAngle()</h4>
+<h5 id="description_44">Description:</h5>
+<p>Returns the angle [rad] of the current User Coordinate System.</p>
+<h5 id="method-signatures_43">Method Signatures:</h5>
+<pre><code class="language-lua">getUcsAngle()
+</code></pre>
+<p>Returns <code>Double</code>.</p>
+<h4 id="getunionofcollections">getUnionOfCollections()</h4>
+<h5 id="description_45">Description:</h5>
+<p>Returns union of collection(s)</p>
+<h5 id="method-signatures_44">Method Signatures:</h5>
+<pre><code class="language-lua">getUnionOfCollections(Collection&lt;Collection&gt; collections, bool unique = true)
+</code></pre>
+<p>Returns <code>Collection&lt;Object&gt;, number Count</code>.</p>
+<h5 id="example_5">Example:</h5>
+<pre><code class="language-lua">r1, n1 = getRelatedObjects(&quot;relation1&quot;)
+r2, n2 = getRelatedObjects(&quot;relation2&quot;)
+r, n = getUnionOfCollections({r1, r2}) -- Writing getRelatedObjects inside getUnionOfCollections won't work because it returns both r1 and n1.
+</code></pre>
+<h4 id="getupobject">getUpObject()</h4>
+<h5 id="description_46">Description:</h5>
+<p>Searches in the up direction and returns the next object along the search's path.
+ - The search starts at the given IBaseObject or AlignmentPos.
+ - If an rcType is specified then the search skips objects of other types.
+ - If searchInvisible is false then the search skips objects on invisible layers.</p>
+<h5 id="method-signatures_45">Method Signatures:</h5>
+<pre><code class="language-lua">getUpObject(IBaseObject sourceObject = this, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getUpObject(AlignmentPos sourceAlignmentPos, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getUpObject(IBaseObject sourceObject = this, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getUpObject(AlignmentPos sourceAlignmentPos, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+</code></pre>
+<p>Returns <code>IBaseObject</code>.</p>
+<h5 id="example_6">Example:</h5>
+<pre><code class="language-lua">getUpObject(this, rctype_Signal) -- This example can be called from a placed object.
+</code></pre>
+<h4 id="getupobjectswithpaths">getUpObjectsWithPaths()</h4>
+<h5 id="description_47">Description:</h5>
+<p>Searches in the up direction and returns a list of tuples (object, path to object). For each path in the up direction the function searches for the first object it encounters along that path and returns the tuple (object, path to object).
+ - The search starts at the given IBaseObject or AlignmentPos.
+ - If an rcType is specified then the search skips objects of other types.</p>
+<p>The returned tuples are ordered by ascending path lengths.</p>
+<h5 id="method-signatures_46">Method Signatures:</h5>
+<pre><code class="language-lua">getUpObjectsWithPaths(IBaseObject sourceObject = this, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getUpObjectsWithPaths(AlignmentPos sourceAlignmentPos, String rcType = nil, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getUpObjectsWithPaths(IBaseObject sourceObject = this, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+getUpObjectsWithPaths(AlignmentPos sourceAlignmentPos, Collection&lt;String&gt; rcTypes = { }, Boolean searchInvisible = false, LuaFunction goalFunction = nil)
+</code></pre>
+<p>Returns <code>Collection&lt;ObjectAndPath&gt;, number Count</code>.</p>
+<h5 id="example_7">Example:</h5>
+<pre><code class="language-lua">getUpObjectWithPaths(this, rctype_Signal) -- This example can be called from a placed object.
+</code></pre>
+<h4 id="geturldrive">getUrlDrive()</h4>
+<h5 id="description_48">Description:</h5>
+<p>Returns drive letter. Default url is the current document.</p>
+<h5 id="method-signatures_47">Method Signatures:</h5>
+<pre><code class="language-lua">getUrlDrive([string url])
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="geturldriveandfolder">getUrlDriveAndFolder()</h4>
+<h5 id="description_49">Description:</h5>
+<p>Returns drive letter and folder name. Default url is the current document.</p>
+<h5 id="method-signatures_48">Method Signatures:</h5>
+<pre><code class="language-lua">getUrlDriveAndFolder([string url])
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="geturldriveandfolderandfilename">getUrlDriveAndFolderAndFilename()</h4>
+<h5 id="description_50">Description:</h5>
+<p>Returns drive letter, folder name and file name. Default url is the current document.</p>
+<h5 id="method-signatures_49">Method Signatures:</h5>
+<pre><code class="language-lua">getUrlDriveAndFolderAndFilename([string url])
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="geturlextension">getUrlExtension()</h4>
+<h5 id="description_51">Description:</h5>
+<p>Returns filename extension (file type). Default url is the current document.</p>
+<h5 id="method-signatures_50">Method Signatures:</h5>
+<pre><code class="language-lua">getUrlExtension([string url])
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="geturlfilename">getUrlFilename()</h4>
+<h5 id="description_52">Description:</h5>
+<p>Returns filename without extension. Default url is the current document.</p>
+<h5 id="method-signatures_51">Method Signatures:</h5>
+<pre><code class="language-lua">getUrlFilename([string url])
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="geturlfilenameandextension">getUrlFilenameAndExtension()</h4>
+<h5 id="description_53">Description:</h5>
+<p>Returns filename with extension. Default url is the current document.</p>
+<h5 id="method-signatures_52">Method Signatures:</h5>
+<pre><code class="language-lua">getUrlFilename([string url])
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="geturlfolder">getUrlFolder()</h4>
+<h5 id="description_54">Description:</h5>
+<p>Returns drive letter and folder name. Default url is the current document.</p>
+<h5 id="method-signatures_53">Method Signatures:</h5>
+<pre><code class="language-lua">getUrlFolder([string url])
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="getvariantnames">getVariantNames()</h4>
+<h5 id="description_55">Description:</h5>
+<p>Returns a list of the variant names for a given RailCOMPLETE type.</p>
+<h5 id="method-signatures_54">Method Signatures:</h5>
+<pre><code class="language-lua">getVariantNames(string rcType)
+</code></pre>
+<p>Returns <code>List&lt;string&gt;, int, LuaFunctionResult</code>.</p>
+<h4 id="getvectorangle">getVectorAngle()</h4>
+<h5 id="description_56">Description:</h5>
+<p>Returns the angle [rad] of the input Point3D, interpreted as a vector.</p>
+<h5 id="method-signatures_55">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorAngle(Point3D u)
+</code></pre>
+<p>Returns <code>Double</code>.</p>
+<h4 id="getvectoranglecossin">getVectorAngleCosSin()</h4>
+<h5 id="description_57">Description:</h5>
+<p>Returns cosa,sina where cosa = u.v/|u||v| and sina = |uxv|/|u||v| (0..180 degrees).</p>
+<h5 id="method-signatures_56">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorAngleCosSin(Point3D u, Point3D v)
+</code></pre>
+<p>Returns <code>Double, Double</code>.</p>
+<h4 id="getvectorangledd">getVectorAngleDD()</h4>
+<h5 id="description_58">Description:</h5>
+<p>Returns the unsigned angle [Decimal Degrees] between two 3D vectors u,v (0..180 degrees).</p>
+<h5 id="method-signatures_57">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorAngleDD(Point3D u, Point3D v)
+</code></pre>
+<p>Returns <code>Double</code>.</p>
+<h4 id="getvectorcrossproduct">getVectorCrossProduct()</h4>
+<h5 id="description_59">Description:</h5>
+<p>Returns the cross product uxv of two 3D vectors u,v.</p>
+<h5 id="method-signatures_58">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorCrossProduct(Point3D u, Point3D v)
+</code></pre>
+<p>Returns <code>Point3D</code>.</p>
+<h4 id="getvectordifference">getVectorDifference()</h4>
+<h5 id="description_60">Description:</h5>
+<p>Returns the subtraction u-v of two 3D vectors u,v.</p>
+<h5 id="method-signatures_59">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorDifference(Point3D u, Point3D v)
+</code></pre>
+<p>Returns <code>Point3D</code>.</p>
+<h4 id="getvectordotproduct">getVectorDotProduct()</h4>
+<h5 id="description_61">Description:</h5>
+<p>Returns the dot product u.v of two 3D vectors u,v.</p>
+<h5 id="method-signatures_60">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorDotProduct(Point3D u, Point3D v)
+</code></pre>
+<h4 id="getvectormodulus">getVectorModulus()</h4>
+<h5 id="description_62">Description:</h5>
+<p>Returns the norm |u| of a 3D vector u.</p>
+<h5 id="method-signatures_61">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorModulus(Point3D u)
+</code></pre>
+<h4 id="getvectornormalized">getVectorNormalized()</h4>
+<h5 id="description_63">Description:</h5>
+<p>Returns a normalized non-zero 3D vector u/|u|.</p>
+<h5 id="method-signatures_62">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorNormalized(Point3D u)
+</code></pre>
+<p>Returns <code>Point3D</code>.</p>
+<h4 id="getvectorscalarproduct">getVectorScalarProduct()</h4>
+<h5 id="description_64">Description:</h5>
+<p>Returns the scalar product mu of scalar m with 3D vector u.</p>
+<h5 id="method-signatures_63">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorScalarProduct(double m, Point3D u)
+</code></pre>
+<p>Returns <code>Point3D</code>.</p>
+<h4 id="getvectorsum">getVectorSum()</h4>
+<h5 id="description_65">Description:</h5>
+<p>Returns the sum of N 3D vectors v1, v2,...,vN: v1 + v2 +... + vN.</p>
+<h5 id="method-signatures_64">Method Signatures:</h5>
+<pre><code class="language-lua">getVectorSum(Point3D u, Point3D v)
+</code></pre>
+<p>Returns <code>Point3D</code>.</p>
+<h4 id="getversion">getVersion()</h4>
+<h5 id="description_66">Description:</h5>
+<p>Returns a table with version information about RailCOMPLETE and the Dna, if there is one.</p>
+<h5 id="method-signatures_65">Method Signatures:</h5>
+<pre><code class="language-lua">getVersion()
+</code></pre>
+<p>Returns <code>Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;</code>.</p>
+<h4 id="getxrefpath">getXrefPath()</h4>
+<h5 id="description_67">Description:</h5>
+<p>Returns the XRefs the object lies within, from inner to outermost.</p>
+<h5 id="method-signatures_66">Method Signatures:</h5>
+<pre><code class="language-lua">getXrefPath(IBaseObject railwayObject)
+</code></pre>
+<p>Returns <code>Collection&lt;IBaseObject&gt;, number Count</code>.</p>
+<h4 id="getzeros">getZeros()</h4>
+<h5 id="description_68">Description:</h5>
+<p>Searches for zeros.</p>
+<h5 id="method-signatures_67">Method Signatures:</h5>
+<pre><code class="language-lua">getZeros(LuaFunction formula, LuaTable optionalArguments)
+</code></pre>
+<p>Returns <code>Collection&lt;Double&gt;, number Count</code>.</p>
+<h4 id="includeluafile">includeLuaFile()</h4>
+<h5 id="description_69">Description:</h5>
+<p>Loads the functions and globals from an external .lua file and returns a LuaTable containing these.</p>
+<h5 id="method-signatures_68">Method Signatures:</h5>
+<pre><code class="language-lua">include(String filePath)
+</code></pre>
+<p>Returns <code>LuaTable</code>.</p>
+<h5 id="example_8">Example:</h5>
+<pre><code class="language-lua">--[[ Contents of &quot;example.lua&quot;: 
+    eulerNumber = 2.71828182845904523536028747135266249775724709369995
+]]
+
+local ex = include(&quot;example.lua&quot;)
+return ex.eulerNumber
+</code></pre>
+<h4 id="isobjectreachablebypath">isObjectReachableByPath()</h4>
+<h5 id="description_70">Description:</h5>
+<p>Checks if a given object is reachable from the inspected object by a path.</p>
+<h5 id="method-signatures_69">Method Signatures:</h5>
+<pre><code class="language-lua">isObjectReachableByPath(IBaseObject placedObject)
+</code></pre>
+<p>Returns <code>Bool</code>.</p>
+<h4 id="isvisible">isVisible()</h4>
+<h5 id="description_71">Description:</h5>
+<p>Checks if the object is visible in the drawing.</p>
+<h5 id="method-signatures_70">Method Signatures:</h5>
+<pre><code class="language-lua">isVisible(this railwayObject:)
+</code></pre>
+<p>Returns <code>Bool</code>.</p>
+<h4 id="orderbyascending">orderByAscending()</h4>
+<h5 id="description_72">Description:</h5>
+<p>Order collection by ascending values. Uses alphanumeric comparer on string representation of objects.</p>
+<h5 id="method-signatures_71">Method Signatures:</h5>
+<pre><code class="language-lua">orderByAscending(this IEnumerable&lt;object&gt; collection:)
+</code></pre>
+<p>Returns <code>Collection&lt;object&gt;, number Count</code>.</p>
+<h4 id="orderbydescending">orderByDescending()</h4>
+<h5 id="description_73">Description:</h5>
+<p>Order collection by descending values. Uses alphanumeric comparer on string representation of objects.</p>
+<h5 id="method-signatures_72">Method Signatures:</h5>
+<pre><code class="language-lua">orderByDescending(this IEnumerable&lt;object&gt; collection:)
+</code></pre>
+<p>Returns <code>Collection&lt;object&gt;, number Count</code>.</p>
+<h4 id="prettyprintpath">prettyPrintPath()</h4>
+<h5 id="description_74">Description:</h5>
+<p>Returns an extended description of a path.</p>
+<h5 id="method-signatures_73">Method Signatures:</h5>
+<pre><code class="language-lua">prettyPrintPath(this railwayPath:)
+</code></pre>
+<p>Returns <code>string</code>.</p>
+<h3 id="cadinterface">cadInterface</h3>
+<p>The following functions are collected in table 'cadInterface'</p>
+<h4 id="blockexist">blockExist()</h4>
+<h5 id="description_75">Description:</h5>
+<p>Check if a block exists in the BlockTable</p>
+<h5 id="method-signatures_74">Method Signatures:</h5>
+<pre><code class="language-lua">blockExist(String blockName)
+</code></pre>
+<h4 id="getcadcolor">getCadColor()</h4>
+<h5 id="description_76">Description:</h5>
+<p>Get the CadColor</p>
+<h5 id="method-signatures_75">Method Signatures:</h5>
+<pre><code class="language-lua">getCadColor(String color)
+</code></pre>
+<h4 id="getguid">getGUID()</h4>
+<h5 id="description_77">Description:</h5>
+<p>Returns a GUID.</p>
+<h5 id="method-signatures_76">Method Signatures:</h5>
+<pre><code class="language-lua">getGUID()
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="getlatitudelongitudealtitudefromwcspoint">getLatitudeLongitudeAltitudeFromWcsPoint()</h4>
+<h5 id="description_78">Description:</h5>
+<p>Get latitude, longitude and altitude as a Point3D from WCS point.</p>
+<h5 id="method-signatures_77">Method Signatures:</h5>
+<pre><code class="language-lua">getLatitudeLongitudeAltitudeFromWcsPoint(Point3D wcsPoint)
+</code></pre>
+<h4 id="gettextstyleid">getTextStyleId()</h4>
+<h5 id="description_79">Description:</h5>
+<p>Get TextStyle ObjectId from Text Style name</p>
+<h5 id="method-signatures_78">Method Signatures:</h5>
+<pre><code class="language-lua">getTextStyleId(string textStyleName)
+</code></pre>
+<h4 id="getwcspointfromlatitudelongitudealtitude">getWcsPointFromLatitudeLongitudeAltitude()</h4>
+<h5 id="description_80">Description:</h5>
+<p>Get WCS point from latitude, longitude and altitude.</p>
+<h5 id="method-signatures_79">Method Signatures:</h5>
+<pre><code class="language-lua">getWcsPointFromLatitudeLongitudeAltitude(double latitude, double longitude, double altitude)
+</code></pre>
+<h4 id="isactivetogglecommand">isActiveToggleCommand()</h4>
+<h5 id="description_81">Description:</h5>
+<p>Returns a read only dictionary with document toggle command names (without 'Rc-') as keys and booleans as values, indicating if the command is currently toggled 'On' (true) or 'Off' (false).</p>
+<h5 id="method-signatures_80">Method Signatures:</h5>
+<pre><code class="language-lua">isActiveToggleCommand()
+</code></pre>
+<p>Returns <code>ReturnType</code>.</p>
+<h4 id="setgeolocationdata">setGeoLocationData()</h4>
+<h5 id="description_82">Description:</h5>
+<p>Set GeoLocation in drawing.</p>
+<h5 id="method-signatures_81">Method Signatures:</h5>
+<pre><code class="language-lua">setGeoLocationData(String coordinateReferenceSystem)
+</code></pre>
+<h3 id="deprecated">Deprecated</h3>
+<h4 id="createobjectusingreflection">createObjectUsingReflection()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#createexternallibraryobject">createExternalLibraryObject()</a> instead.</p>
+</div>
+<h5 id="description_83">Description:</h5>
+<p>Creates instance of an object using reflection.</p>
+<h5 id="method-signatures_82">Method Signatures:</h5>
+<pre><code class="language-lua">createObjectUsingReflection(String name, Collection args, Table initializePropertyDictionary)
+</code></pre>
+<p>Returns <code>object</code>.</p>
+<h4 id="distance">distance()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#getdistance">getDistance()</a> instead.</p>
+</div>
+<h5 id="description_84">Description:</h5>
+<p>Calculates distance-along-path.</p>
+<p>This is the distance measured along the XY plane geometry of the shortest path from the source object's projection onto its own alignment to the target object's projection onto its own alignment. If no such path exists then 'NaN' is returned. 
+The Z coordinate and the effect of cant are disregarded if the alignments are 3D railway tracks with cant.</p>
+<h5 id="method-signatures_83">Method Signatures:</h5>
+<pre><code class="language-lua">distance(IPlacedObjectBase toObject)
+distance(this IPlacedObjectBase fromObject:, IPlacedObjectBase toObject)
+</code></pre>
+<p>Returns <code>Double</code>.</p>
+<h4 id="getclosestalignments">getClosestAlignments()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#getnearbyalignments">getNearbyAlignments()</a> instead.</p>
+</div>
+<h5 id="description_85">Description:</h5>
+<p>Returns the alignments sorted by proximity.</p>
+<h5 id="method-signatures_84">Method Signatures:</h5>
+<pre><code class="language-lua">getClosestAlignments(this reference:, String rcType = nil, Boolean searchInvisible = false)
+getClosestAlignments(Double X, Double Y, String rcType = nil, Boolean searchInvisible = false)
+getClosestAlignments(Point3D point, String rcType = nil, Boolean searchInvisible = false)
+</code></pre>
+<p>Returns <code>Collection&lt;IAlignment&gt;, number Count</code>.</p>
+<h4 id="getclosesttracks">getClosestTracks()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#getnearbyalignments">getNearbyAlignments()</a> instead.</p>
+</div>
+<h5 id="description_86">Description:</h5>
+<p>Returns the tracks sorted by proximity.</p>
+<h5 id="method-signatures_85">Method Signatures:</h5>
+<pre><code class="language-lua">getClosestTracks(Boolean searchInvisible = false)
+getClosestTracks(this reference:, Boolean searchInvisible = false)
+getClosestTracks(Double X, Double Y, Boolean searchInvisible = false)
+getClosestTracks(Point3D point, Boolean searchInvisible = false)
+</code></pre>
+<p>Returns <code>Collection&lt;IAlignment&gt;, number Count</code>.</p>
+<h4 id="getcollectionofrelatedobjects">getCollectionOfRelatedObjects()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#getrelatedobjects">getRelatedObjects()</a> instead.</p>
+</div>
+<h5 id="description_87">Description:</h5>
+<p>Returns a collection of objects connected through the specified relation, and the number of related objects found. Source object and visibility are optional arguments.</p>
+<h5 id="method-signatures_86">Method Signatures:</h5>
+<pre><code class="language-lua">getCollectionOfRelatedObjects(String relationName, IBaseObject sourceObject = this, Boolean Invisible = false)
+</code></pre>
+<p>Returns <code>Collection&lt;IBaseObject&gt;, number Count</code>.</p>
+<h4 id="include">include()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#includeluafile">includeLuaFile()</a> instead.</p>
+</div>
+<h5 id="description_88">Description:</h5>
+<p>Loads the functions and globals from an external .lua file and returns a LuaTable containing these.</p>
+<h5 id="method-signatures_87">Method Signatures:</h5>
+<pre><code class="language-lua">include(String filePath)
+</code></pre>
+<p>Returns <code>LuaTable</code>.</p>
+<h4 id="prop">prop()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#getpropertyfromdisplayname">getPropertyFromDisplayName()</a> instead.</p>
+</div>
+<h5 id="description_89">Description:</h5>
+<p>Returns property from display name.</p>
+<h2 id="script-lua-functions">Script Lua Functions</h2>
+<h4 id="addrepresentation3d">addRepresentation3D()</h4>
+<h5 id="description_90">Description:</h5>
+<p>Perform an edit text attribute operation on a text attribute.</p>
+<h5 id="method-signatures_88">Method Signatures:</h5>
+<pre><code class="language-lua">addRepresentation(this IRailwayObject railwayObject:, string representationType)
+</code></pre>
+<p>Returns <code>Void</code>.</p>
+<h4 id="askforalignment">askForAlignment()</h4>
+<h5 id="description_91">Description:</h5>
+<p>The CAD application will prompt the user for an alignment RailwayObject. A default alignment RailwayObject can be provided.</p>
+<h5 id="method-signatures_89">Method Signatures:</h5>
+<pre><code class="language-lua">askForAlignment(String message, IAlignment defaultAlignment = nil)
+</code></pre>
+<p>Returns <code>IAlignment</code>.</p>
+<h5 id="example_9">Example:</h5>
+<pre><code class="language-lua">local alignment = askForAlignment(&quot;Please select an alignment&quot;)
+write(alignment.AlignmentSystem)
+</code></pre>
+<h4 id="askfordouble">askForDouble()</h4>
+<h5 id="description_92">Description:</h5>
+<p>The CAD application will prompt the user for a double value. A default value can be provided.</p>
+<h5 id="method-signatures_90">Method Signatures:</h5>
+<pre><code class="language-lua">askForDouble(String message, Double defaultValue = nil)
+</code></pre>
+<p>Returns <code>Double</code>.</p>
+<h5 id="example_10">Example:</h5>
+<pre><code class="language-lua">local number = askForDouble(&quot;Please input number to be squared:&quot;)
+write(number*number)
+</code></pre>
+<h4 id="askforfilename">askForFileName()</h4>
+<h5 id="description_93">Description:</h5>
+<p>The CAD application will make the user browse for a file. A default file name can be provided.</p>
+<h5 id="method-signatures_91">Method Signatures:</h5>
+<pre><code class="language-lua">askForFileName(String message, string DefaultFileName = nil)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h5 id="example_11">Example:</h5>
+<pre><code class="language-lua">local filename = askForFileName(&quot;Please select a file&quot;)
+write(filename)
+</code></pre>
+<h4 id="askforfoldername">askForFolderName()</h4>
+<h5 id="description_94">Description:</h5>
+<p>The CAD application will make the user browse for a folder. A default folder name can be provided.</p>
+<h5 id="method-signatures_92">Method Signatures:</h5>
+<pre><code class="language-lua">askForFolder(String message, string DefaultFolderName = nil)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h5 id="example_12">Example:</h5>
+<pre><code class="language-lua">local folderName = askForFolderName(&quot;Please select a folder&quot;)
+write(folderName)
+</code></pre>
+<h4 id="askforinteger">askForInteger()</h4>
+<h5 id="description_95">Description:</h5>
+<p>The CAD application will prompt the user for an integer value. A default integer can be provided.</p>
+<h5 id="method-signatures_93">Method Signatures:</h5>
+<pre><code class="language-lua">askForInteger(String message, Int defaultValue = nil)
+</code></pre>
+<p>Returns <code>Int</code>.</p>
+<h5 id="example_13">Example:</h5>
+<pre><code class="language-lua">local number = askForInteger(&quot;Please input integer to be squared:&quot;)
+write(number*number)
+</code></pre>
+<h4 id="askforkeyword">askForKeyword()</h4>
+<h5 id="description_96">Description:</h5>
+<p>The CAD application will prompt the user for a keyword value.</p>
+<h5 id="method-signatures_94">Method Signatures:</h5>
+<pre><code class="language-lua">askForKeyword(String message, LuaTable&lt;String&gt; keywords, String title = 'Keyword', Boolean useCadPrompt = false, Symbol symbol = Symbol._noSymbol, FontType fontType = FontType.Proportional)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="askforobject">askForObject()</h4>
+<h5 id="description_97">Description:</h5>
+<p>The CAD application will prompt the user for a RailwayObject. A default RailwayObject can be provided.</p>
+<h5 id="method-signatures_95">Method Signatures:</h5>
+<pre><code class="language-lua">askForObject(String message, IBaseObject defaultRailwayObject = nil)
+</code></pre>
+<p>Returns <code>IBaseObject</code>.</p>
+<h5 id="example_14">Example:</h5>
+<pre><code class="language-lua">local object = askForObject(&quot;Please provide an object&quot;)
+write(object.code)
+</code></pre>
+<h4 id="askforpath">askForPath()</h4>
+<h5 id="description_98">Description:</h5>
+<p>The CAD application will prompt the user for a path. A default path can be provided.</p>
+<h5 id="method-signatures_96">Method Signatures:</h5>
+<pre><code class="language-lua">askForPath(RailwayPath defaultPath = nil)
+</code></pre>
+<p>Returns <code>RailwayPath</code>.</p>
+<h5 id="example_15">Example:</h5>
+<pre><code class="language-lua">local path = askForPath()
+write(path:prettyPrintPath())
+</code></pre>
+<h4 id="askforpoint">askForPoint()</h4>
+<h5 id="description_99">Description:</h5>
+<p>The CAD application will prompt the user for a point. A default point can be provided.</p>
+<h5 id="method-signatures_97">Method Signatures:</h5>
+<pre><code class="language-lua">askForPoint(String message, Point3D defaultValue = nil)
+</code></pre>
+<p>Returns <code>Point3D</code>.</p>
+<h5 id="example_16">Example:</h5>
+<pre><code class="language-lua">local point = askForPoint(&quot;Please provide a point&quot;)
+write(point.X)
+</code></pre>
+<h4 id="askforpointobject">askForPointObject()</h4>
+<h5 id="description_100">Description:</h5>
+<p>The CAD application will prompt the user for a placed RailwayObject. A default placed RailwayObject can be provided.</p>
+<h5 id="method-signatures_98">Method Signatures:</h5>
+<pre><code class="language-lua">askForPointObject(String message, IPlacedObjectBase defaultPointObject = nil)
+</code></pre>
+<p>Returns <code>IPlacedObjectBase</code>.</p>
+<h5 id="example_17">Example:</h5>
+<pre><code class="language-lua">local object = askForPointObject(&quot;Please provide a point object&quot;)
+write(object.code)
+</code></pre>
+<h4 id="askforstring">askForString()</h4>
+<h5 id="description_101">Description:</h5>
+<p>The CAD application will prompt the user for a string value. A default string can be provided.</p>
+<h5 id="method-signatures_99">Method Signatures:</h5>
+<pre><code class="language-lua">askForString(String message, String defaultValue = &quot;&quot;)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h5 id="example_18">Example:</h5>
+<pre><code class="language-lua">local message = askForString(&quot;Please provide a string&quot;)
+write(message)
+</code></pre>
+<h4 id="beginundobufferitem">beginUndoBufferItem()</h4>
+<h5 id="description_102">Description:</h5>
+<p>Wraps up the code until endUndoBufferItem() into one CAD transaction.
+Warning: Do not run CAD commands using runCommand() function between beginUndoBufferItem() and endUndoBufferItem().</p>
+<h5 id="method-signatures_100">Method Signatures:</h5>
+<pre><code class="language-lua">beginUndoBufferItem()
+</code></pre>
+<h4 id="create3dpolyline">create3DPolyline()</h4>
+<h5 id="description_103">Description:</h5>
+<p>Create a 3D polyline</p>
+<h5 id="method-signatures_101">Method Signatures:</h5>
+<pre><code class="language-lua">create3DPolyline(Collection&lt;Point3D&gt; points)
+</code></pre>
+<h4 id="createcantevent">createCantEvent()</h4>
+<h5 id="description_104">Description:</h5>
+<p>Returns a CantEvent.</p>
+<h5 id="method-signatures_102">Method Signatures:</h5>
+<pre><code class="language-lua">createCantEvent(Double pos, Double leftSuperelevation = 0, rightSuperelevation = 0)
+</code></pre>
+<p>Returns <code>CantEvent</code>.</p>
+<h4 id="createcantprofile">createCantProfile()</h4>
+<h5 id="description_105">Description:</h5>
+<p>This method's signatures mentions cant segments. In the context of this function a cant segment is a collection of two CantEvents.</p>
+<h5 id="method-signatures_103">Method Signatures:</h5>
+<pre><code class="language-lua">createCantProfile(Collection&lt;CantEvents&gt; cantEvents)
+createCantProfile(Collection&lt;Collection&lt;CantEvents&gt;&gt; cantSegments)
+</code></pre>
+<p>Returns <code>CantProfile</code>.</p>
+<h4 id="createclothoidsegment">createClothoidSegment()</h4>
+<h5 id="description_106">Description:</h5>
+<p>Create a clothoid segment.</p>
+<h5 id="method-signatures_104">Method Signatures:</h5>
+<pre><code class="language-lua">CreateClothoidSegment(Point3D startPoint, double startDirectionInDegrees, double length, double startRadius, double clothoidParameter, bool increasingCurvature).
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h5 id="example_19">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment(p2, d1, l1, 0, math.sqrt(l1*r), true)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+createAlignmentObject(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+
+</code></pre>
+<h4 id="createclothoidsegment2">createClothoidSegment2()</h4>
+<h5 id="description_107">Description:</h5>
+<p>RunScriptLuaContext_CreateClothoidSegment_Description</p>
+<h5 id="method-signatures_105">Method Signatures:</h5>
+<pre><code class="language-lua">CreateClothoidSegment(Point3D startPoint, double startDirectionInDegrees, double length, double startRadius, double endRadius).
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h5 id="example_20">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment2(p2, d1, l1, 0, r)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+createAlignmentObject(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+</code></pre>
+<h4 id="createclothoidsegmentfromneighbors">createClothoidSegmentFromNeighbors()</h4>
+<h5 id="description_108">Description:</h5>
+<p>Creates a clothoid segment to fill the gap between a leading and a trailing Line or Curve.
+Note: this method can be unstable.</p>
+<h5 id="method-signatures_106">Method Signatures:</h5>
+<pre><code class="language-lua">CreateClothoidSegmentFromNeighbors(HorizontalGeometryModel.Segment startCircle, HorizontalGeometryModel.Segment endCircle)
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h4 id="createcosinespiralsegment">createCosineSpiralSegment()</h4>
+<h5 id="description_109">Description:</h5>
+<p>Create a CosineSpiral segment.</p>
+<h5 id="method-signatures_107">Method Signatures:</h5>
+<pre><code class="language-lua">CreateCosineSpiralSegment(Point3D startPoint, double startDirectionInDegrees, double length, double startRadius, bool increasingCurvature, double characteristicLength, double characteristicRadius).
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h4 id="createcurvesegment">createCurveSegment()</h4>
+<h5 id="description_110">Description:</h5>
+<p>Create a curve segment.</p>
+<h5 id="method-signatures_108">Method Signatures:</h5>
+<pre><code class="language-lua">createCurveSegment(Point3D startPoint, Double startDirectionInDegrees, Double length, Double radius)
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h5 id="example_21">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment2(p2, d1, l1, 0, r)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+createAlignmentObject(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+</code></pre>
+<h4 id="createcurvesegment2">createCurveSegment2()</h4>
+<h5 id="description_111">Description:</h5>
+<p>Create a curve segment.</p>
+<h5 id="method-signatures_109">Method Signatures:</h5>
+<pre><code class="language-lua">createCurveSegment2(Point3D startPoint, Double startDirectionInDegrees, Point3D endPoint)
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h4 id="createcurvesegment3">createCurveSegment3()</h4>
+<h5 id="description_112">Description:</h5>
+<p>Create a curve segment. middlePoint is a point on the curve.</p>
+<h5 id="method-signatures_110">Method Signatures:</h5>
+<pre><code class="language-lua">createCurveSegment3(Point3D startPoint, Point3D middlePoint, Point3D endPoint)
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h4 id="createhorizontalgeometry">createHorizontalGeometry()</h4>
+<h5 id="description_113">Description:</h5>
+<p>Create horizontal geometry from horizontal segments.</p>
+<h5 id="method-signatures_111">Method Signatures:</h5>
+<pre><code class="language-lua">createHorizontalGeometry(Collection&lt;Segment&gt; segments)
+</code></pre>
+<p>Returns <code>HorizontalGeometry</code>.</p>
+<h5 id="example_22">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment2(p2, d1, l1, 0, r)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+createAlignmentObject(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+</code></pre>
+<h4 id="createlinesegment">createLineSegment()</h4>
+<h5 id="description_114">Description:</h5>
+<p>Create an alignment from HorizontalGeometry.</p>
+<h5 id="method-signatures_112">Method Signatures:</h5>
+<pre><code class="language-lua">createLineSegment(Point3D startPoint, Point3D endPoint)
+</code></pre>
+<p>Returns <code>Segment</code>.</p>
+<h5 id="example_23">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment2(p2, d1, l1, 0, r)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+createAlignmentObject(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+</code></pre>
+<h4 id="createmileageevent">createMileageEvent()</h4>
+<h5 id="description_115">Description:</h5>
+<p>Available mileage event types:
+ - Start (must have DistanceAlong 0)
+ - ChainBreak
+ - Milepost</p>
+<h5 id="method-signatures_113">Method Signatures:</h5>
+<pre><code class="language-lua">createMileageEvent(Double pos, Double mileage, String eventType, String name = &quot;&quot;)
+</code></pre>
+<p>Returns <code>MileageChange</code>.</p>
+<h4 id="createmileageprofile">createMileageProfile()</h4>
+<h5 id="description_116">Description:</h5>
+<p>If the input mileage changes contain a Start event with pos 0, then that is used as start mileage. If not, start mileage is derived from the first mileage event.</p>
+<h5 id="method-signatures_114">Method Signatures:</h5>
+<pre><code class="language-lua">createMileageProfile(Collection&lt;MileageChange&gt; mileageChanges)
+</code></pre>
+<p>Returns <code>Mileage</code>.</p>
+<h4 id="createspeedevent">createSpeedEvent()</h4>
+<h5 id="description_117">Description:</h5>
+<p>Returns a SpeedEvent.</p>
+<h5 id="method-signatures_115">Method Signatures:</h5>
+<pre><code class="language-lua">createSpeedEvent(Double pos, Double leftSuperelevation = 0, rightSuperelevation = 0)
+</code></pre>
+<p>Returns <code>SpeedEvent</code>.</p>
+<h4 id="createspeedprofile">createSpeedProfile()</h4>
+<h5 id="description_118">Description:</h5>
+<p>Returns a SpeedProfile.</p>
+<h5 id="method-signatures_116">Method Signatures:</h5>
+<pre><code class="language-lua">createSpeedProfile(Collection&lt;SpeedEvents&gt; SpeedEvents)
+</code></pre>
+<p>Returns <code>SpeedProfile</code>.</p>
+<h4 id="createverticalevent">createVerticalEvent()</h4>
+<h5 id="description_119">Description:</h5>
+<p>Returns a VerticalEvent: If radius is nil, 0, NaN or infinite then the returned VerticalEvent is a PVI. Otherwise it is a Curve.</p>
+<h5 id="method-signatures_117">Method Signatures:</h5>
+<pre><code class="language-lua">createVerticalEvent(Double pos, Double elevation, Double radius = nil)
+</code></pre>
+<p>Returns <code>VerticalEvent</code>.</p>
+<h4 id="createverticalprofile">createVerticalProfile()</h4>
+<h5 id="description_120">Description:</h5>
+<p>This method's signatures mentions vertical segments. In the context of this function a vertical segment is a collection of VerticalEvents. A linear vertical segment is a collection of two PVIs. A curve vertical segment is a collection of three VerticalEvents: a PVI followed by a Curve followed by a PVI.</p>
+<h5 id="method-signatures_118">Method Signatures:</h5>
+<pre><code class="language-lua">createVerticalProfile(Collection&lt;VerticalEvents&gt; verticalEvents)
+createVerticalProfile(Collection&lt;Collection&lt;VerticalEvents&gt;&gt; verticalSegments)
+</code></pre>
+<p>Returns <code>VerticalProfile</code>.</p>
+<h4 id="deserializejson">deserializeJson()</h4>
+<h5 id="description_121">Description:</h5>
+<p>Deserialize a JSON file to the provided object type.</p>
+<h5 id="method-signatures_119">Method Signatures:</h5>
+<pre><code class="language-lua">deserializeJson(String fileName, object o, table&lt;JsonConverter&gt; converters = nil)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="deserializexml">deserializeXml()</h4>
+<h5 id="description_122">Description:</h5>
+<p>Deserialize an XML file to the provided object type.</p>
+<h5 id="method-signatures_120">Method Signatures:</h5>
+<pre><code class="language-lua">deserializeXml(String fileName, object o)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="endundobufferitem">endUndoBufferItem()</h4>
+<h5 id="description_123">Description:</h5>
+<p>End a wrapping transaction.</p>
+<h5 id="method-signatures_121">Method Signatures:</h5>
+<pre><code class="language-lua">endUndoBufferItem()
+</code></pre>
+<h4 id="eraseobject">eraseObject()</h4>
+<h5 id="description_124">Description:</h5>
+<p>Erase object.</p>
+<h5 id="method-signatures_122">Method Signatures:</h5>
+<pre><code class="language-lua">eraseObject(IBaseObject object)
+</code></pre>
+<h4 id="exportstringtofile">exportStringToFile()</h4>
+<h5 id="description_125">Description:</h5>
+<p>Export string to file. If no path is specified then you will be prompted to provide one.</p>
+<h5 id="method-signatures_123">Method Signatures:</h5>
+<pre><code class="language-lua">exportStringToFile(String stringToExport, String path = nil)
+</code></pre>
+<p>Returns <code>Void</code>.</p>
+<h4 id="exporttoifc">exportToIfc()</h4>
+<h5 id="description_126">Description:</h5>
+<p>Export objects to IFC.</p>
+<h5 id="method-signatures_124">Method Signatures:</h5>
+<pre><code class="language-lua">exportToIfc(Point3D origin = nil, String folder = nil)
+</code></pre>
+<p>Returns <code>Void</code>.</p>
+<h4 id="exporttojson">exportToJson()</h4>
+<h5 id="description_127">Description:</h5>
+<p>Export Lua table or object to JSON string</p>
+<h5 id="method-signatures_125">Method Signatures:</h5>
+<pre><code class="language-lua">exportToJson(Table t, table&lt;JsonConverter&gt; converters = nil)
+exportToJson(object o, table&lt;JsonConverter&gt; converters = nil)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="exporttoxml">exportToXml()</h4>
+<h5 id="description_128">Description:</h5>
+<p>Export Lua table or object to XML string</p>
+<h5 id="method-signatures_126">Method Signatures:</h5>
+<pre><code class="language-lua">exportToXml(table t)
+exportToXml(object o)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="generateguid">generateGuid()</h4>
+<h5 id="description_129">Description:</h5>
+<p>Returns a GUID as string.</p>
+<h5 id="method-signatures_127">Method Signatures:</h5>
+<pre><code class="language-lua">generateGuid()
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="getfilefrompath">getFileFromPath()</h4>
+<h5 id="description_130">Description:</h5>
+<p>Returns a file matching a specific type and path. If no such file is found then nil is returned instead.
+FileType is required to extract the content of the file. If this is not necessary, then the askForFileName() function may suffice.</p>
+<h5 id="method-signatures_128">Method Signatures:</h5>
+<pre><code class="language-lua">getFileFromPath(FileType fileType, String absolutePath)
+</code></pre>
+<p>Returns <code>File</code>.</p>
+<h4 id="getfilefromprompt">getFileFromPrompt()</h4>
+<h5 id="description_131">Description:</h5>
+<p>Prompts the user to select a file of a specific type and returns the file. If the selection is cancelled then nil is returned instead.
+If a windowTitleOverride is specified, then the prompt window seen by the user will have that as its title. Otherwise their operating system will give the window a default title, such as "Open".
+FileType is required to extract the content of the file. If this is not necessary, then the askForFileName() function may suffice.</p>
+<h5 id="method-signatures_129">Method Signatures:</h5>
+<pre><code class="language-lua">getFileFromPrompt(FileType fileType, String windowTitleOverride = &quot;&quot;)
+</code></pre>
+<p>Returns <code>File</code>.</p>
+<h4 id="getfilesinfolder">getFilesInFolder()</h4>
+<h5 id="description_132">Description:</h5>
+<p>Returns the files in a folder.</p>
+<h5 id="method-signatures_130">Method Signatures:</h5>
+<pre><code class="language-lua">getFilesInFolder(String folder)
+getFilesInFolder(String folder, String searchPattern)
+</code></pre>
+<p>Returns <code>Collection&lt;String&gt;</code>.</p>
+<h4 id="getfoldersinfolder">getFoldersInFolder()</h4>
+<h5 id="description_133">Description:</h5>
+<p>Returns the folders in a folder. Argument folder is full path to folder and optional argument searchPattern is a windows explorer search pattern.</p>
+<h5 id="method-signatures_131">Method Signatures:</h5>
+<pre><code class="language-lua">getFoldersInFolder(String folder)
+getFoldersInFolder(String folder, String searchPattern)
+</code></pre>
+<p>Returns <code>Collection&lt;String&gt;</code>.</p>
+<h4 id="getstartangleforarc">getStartAngleForArc()</h4>
+<h5 id="description_134">Description:</h5>
+<p>Returns start angle for arc given start and end coordinates and radius.</p>
+<h5 id="method-signatures_132">Method Signatures:</h5>
+<pre><code class="language-lua">getStartAngleForArc(Double x1, Double x1, Double x2, Double x2, Double radius)
+</code></pre>
+<h4 id="insertalignment">insertAlignment()</h4>
+<h5 id="description_135">Description:</h5>
+<p>Inserts a new alignment in model space and returns a reference to it.</p>
+<h5 id="method-signatures_133">Method Signatures:</h5>
+<pre><code class="language-lua">insertAlignment(String type, String variant, List&lt;Point3D&gt; polyline3D)
+insertAlignment(String type, String variant, HorizontalGeometry horizontalGeometry, bool requireAudit = true, VerticalProfile verticalProfile = nil, CantProfile cantProfile = nil, SpeedProfile speedProfile = nil, MileageProfile mileageProfile = nil)
+</code></pre>
+<p>Returns <code>IAlignment</code>.</p>
+<h5 id="example_24">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment2(p2, d1, l1, 0, r)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+insertAlignment(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+</code></pre>
+<h4 id="insertalignmentfromrailwaypath">insertAlignmentFromRailwayPath()</h4>
+<h5 id="description_136">Description:</h5>
+<p>Create an alignment from a path. The created alignment is inserted into model space and returned.</p>
+<p>By default, the RcType and Variant of the alignment is taken from the first alignment in the path. This can be changed by using the rcTypeOverride and variantOverride arguments.</p>
+<p>Technical note: After an input Variant has been chosen by the above procedure, the corresponding InsertOption in the DNA is selected, which then sets the final variant. InsertOptions are the items selected in the 'Insert Alignment' UI.
+ - If rcTypeOverride is specified while variantOverride is not, then first InsertOption is chosen. This normally corresponds to the first Variant.
+ - In a few special cases, there is not a 1-1 correspondance between Variants and InsertOptions. If the rcType in question does not have an InsertOptions for the chosen Variant, then the first InsertOption is chosen.</p>
+<h5 id="method-signatures_134">Method Signatures:</h5>
+<pre><code class="language-lua">insertAlignmentFromRailwayPath(RailwayPath railwayPath, String rcTypeOverride = nil, String variantOverride = nil, bool requireAudit = true)
+</code></pre>
+<p>Returns <code>IAlignment</code>.</p>
+<h5 id="example_25">Example:</h5>
+<pre><code class="language-lua">local railwayPath = askForPath() -- Requires user input
+local insertedAlignment = insertAlignmentFromRailwayPath(railwayPath)
+
+</code></pre>
+<h4 id="insertpointobject">insertPointObject()</h4>
+<h5 id="description_137">Description:</h5>
+<p>Inserts a new point object in model space and returns a reference to it.</p>
+<p>The object will have object type ‘rcType’. Its Variant will be deduced by RailCOMPLETE from its insertPointObjectOption string, being one of the possible drop-down options from the ribbon’s insert-point-object command. If no insertPointObjectOption string is given, then the top item from the ribbon’s dropdown list will apply.</p>
+<h5 id="method-signatures_135">Method Signatures:</h5>
+<pre><code class="language-lua">insertPointObject(IAlignment alignment, String rcType, Double pos, Double distanceToAlignment, Boolean insertionSideIsLeft)
+insertPointObject(IAlignment alignment, String rcType, Point3D insertionPoint)
+insertPointObject(IAlignment alignment, String rcType, String insertPointObjectOptions, Double pos, Double distanceToAlignment, Boolean insertionSideIsLeft)
+insertPointObject(IAlignment alignment, String rcType, String insertPointObjectOptions, Point3D insertionPoint)
+</code></pre>
+<p>Returns <code>IPlacedObjectBase</code>.</p>
+<h5 id="example_26">Example:</h5>
+<pre><code class="language-lua">--Example must be run in script context
+local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment(p2, d1, l1, 0, math.sqrt(l1*r), true)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+local alignmentVariant = &quot;Enkle skinner og sviller med ballastprofil&quot; --NO-BN basic track variant
+local alignment = createAlignmentObject(rctype_Track, alignmentVariant, horizontalGeometry)
+
+local signalVariant = &quot;ERTMS E35 Stoppskilt, sidestilt&quot; --NO-BN ERTMS stop sign insertion option name
+local signal1 = insertPointObject(alignment, rctype_EtcsEoA, signalVariant, 600, 4, false)
+</code></pre>
+<h4 id="movepointobject">movePointObject()</h4>
+<h5 id="description_138">Description:</h5>
+<p>Move a point object to a new position.</p>
+<h5 id="method-signatures_136">Method Signatures:</h5>
+<pre><code class="language-lua">movePointObject(IRailwayObject pointObject, Point3D point)
+</code></pre>
+<h4 id="runcommand">runCommand()</h4>
+<h5 id="description_139">Description:</h5>
+<p>Run CAD command.
+Returns a dictionary where element 'log' is a string with any log output of the command and 'result' is a collection of any objects selected by the command.</p>
+<h5 id="method-signatures_137">Method Signatures:</h5>
+<pre><code class="language-lua">runCommand(String command)
+</code></pre>
+<h4 id="runexternallibraryfunction">runExternalLibraryFunction()</h4>
+<h5 id="description_140">Description:</h5>
+<p>Run a static method inside a type and return the result.</p>
+<h5 id="method-signatures_138">Method Signatures:</h5>
+<pre><code class="language-lua">runExternalLibraryFunction(String typeName, String methodName, Collection args)
+</code></pre>
+<p>Returns <code>object</code>.</p>
+<h4 id="setpointobjectdisplayoffset">setPointObjectDisplayOffset()</h4>
+<h5 id="description_141">Description:</h5>
+<p>Set the offset for the display position for a point object in Alignment Coordinate System (ACS).</p>
+<h5 id="method-signatures_139">Method Signatures:</h5>
+<pre><code class="language-lua">setPointObjectDisplayOffset(this IRailwayObject pointObject:, Double offsetX, Double offsetY)
+</code></pre>
+<h4 id="setpointobjectdisplaypoint">setPointObjectDisplayPoint()</h4>
+<h5 id="description_142">Description:</h5>
+<p>Set the display position for a point object.</p>
+<h5 id="method-signatures_140">Method Signatures:</h5>
+<pre><code class="language-lua">setPointObjectDisplayPoint(this IRailwayObject pointObject:, Point3D point)
+</code></pre>
+<h4 id="setrcid">setRcId()</h4>
+<h5 id="description_143">Description:</h5>
+<p>Set new ID for RC object.</p>
+<h5 id="method-signatures_141">Method Signatures:</h5>
+<pre><code class="language-lua">setRcId(IBaseObject obj, string id)
+</code></pre>
+<h4 id="setrelation">setRelation()</h4>
+<h5 id="description_144">Description:</h5>
+<p>Set a relation between two railway objects.</p>
+<h5 id="method-signatures_142">Method Signatures:</h5>
+<pre><code class="language-lua">setRelation(IBaseObject sourceObject, IBaseObject targetObject, string relationPrompt)
+</code></pre>
+<h4 id="setselectionset">setSelectionSet()</h4>
+<h5 id="description_145">Description:</h5>
+<p>Set CAD selection set.</p>
+<h5 id="method-signatures_143">Method Signatures:</h5>
+<pre><code class="language-lua">setSelectionSet(Collection&lt;IBaseObject&gt; objects)
+</code></pre>
+<h4 id="settextattribute">setTextAttribute()</h4>
+<h5 id="description_146">Description:</h5>
+<p>Perform an edit text attribute operation on a text attribute.</p>
+<h5 id="method-signatures_144">Method Signatures:</h5>
+<pre><code class="language-lua">setTextAttribute(IRailwayObject obj, TextAttributeOperation operation, String attributeTag, Object value)
+setTextAttribute(Collection&lt;IRailwayObjects&gt; objects, TextAttributeOperation operation, String attributeTag, Object value)
+</code></pre>
+<h4 id="settextpositionformula">setTextPositionFormula()</h4>
+<h5 id="description_147">Description:</h5>
+<p>Set a text position formula on a placed object.</p>
+<h5 id="method-signatures_145">Method Signatures:</h5>
+<pre><code class="language-lua">setTextPositionFormula(IRailwayObject obj, String attributeTag, String formula)
+</code></pre>
+<h4 id="settextrotationformula">setTextRotationFormula()</h4>
+<h5 id="description_148">Description:</h5>
+<p>Set a text rotation formula on a placed object.</p>
+<h5 id="method-signatures_146">Method Signatures:</h5>
+<pre><code class="language-lua">setTextRotationFormula(IRailwayObject obj, String attributeTag, String formula)
+</code></pre>
+<h4 id="showmessage">showMessage()</h4>
+<h5 id="description_149">Description:</h5>
+<p>Shows a message to the user through the CAD application.</p>
+<h5 id="method-signatures_147">Method Signatures:</h5>
+<pre><code class="language-lua">showMessage(String message, String title = 'Message', Symbol symbol = Symbol._noSymbol, FontType fontType = FontType.Proportional, Boolean AutoWrap = true)
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="updatealignmenthorizontaldata">updateAlignmentHorizontalData()</h4>
+<h5 id="description_150">Description:</h5>
+<p>Updated the horizontal data in an alignment given a horizontal geometry. Previous horizontal geometry is discarded.</p>
+<h5 id="method-signatures_148">Method Signatures:</h5>
+<pre><code class="language-lua">updateAlignmentHorizontalData(IAlignment alignment, HorizontalGeometry horizontalGeometry)
+updateAlignmentHorizontalData(IAlignment alignment, Collection&lt;Point3D&gt; points)
+</code></pre>
+<h4 id="updatealignmentverticaldata">updateAlignmentVerticalData()</h4>
+<h5 id="description_151">Description:</h5>
+<p>Updated the vertical data in an alignment given a collection of 3D points. Previous vertical profile is discarded.</p>
+<h5 id="method-signatures_149">Method Signatures:</h5>
+<pre><code class="language-lua">updateAlignmentVerticalData(IRailwayObject alignment, Collection&lt;Point3D&gt; points, Boolean extendStartAndEnd = false)
+</code></pre>
+<h4 id="write">write()</h4>
+<h5 id="description_152">Description:</h5>
+<p>Write to output.</p>
+<h5 id="method-signatures_150">Method Signatures:</h5>
+<pre><code class="language-lua">write(String text)
+write(String text, Symbol status)
+</code></pre>
+<h3 id="cadinterface_1">cadInterface</h3>
+<p>The following functions are collected in table 'cadInterface'</p>
+<h4 id="addentitiestoblock">addEntitiesToBlock()</h4>
+<h5 id="description_153">Description:</h5>
+<p>Add entities to an existing block.</p>
+<h5 id="method-signatures_151">Method Signatures:</h5>
+<pre><code class="language-lua">addEntitiesToBlock(String blockName, Collection entities, Bool annotative = false)
+</code></pre>
+<h4 id="addentitiestomodelspace">addEntitiesToModelSpace()</h4>
+<h5 id="description_154">Description:</h5>
+<p>Insert entities into model space.</p>
+<h5 id="method-signatures_152">Method Signatures:</h5>
+<pre><code class="language-lua">addEntitiesToModelSpace(Collection entities)
+</code></pre>
+<h4 id="addlayers">addLayers()</h4>
+<h5 id="description_155">Description:</h5>
+<p>Creates a block containing given entities and puts it in the BlockTable</p>
+<h5 id="method-signatures_153">Method Signatures:</h5>
+<pre><code class="language-lua">addLayers(Collection layers)
+</code></pre>
+<h4 id="createblock">createBlock()</h4>
+<h5 id="description_156">Description:</h5>
+<p>Creates a block containing given entities and puts it in the BlockTable</p>
+<h5 id="method-signatures_154">Method Signatures:</h5>
+<pre><code class="language-lua">createBlock(String blockName, Collection entities, Bool annotative = false)
+</code></pre>
+<h4 id="createcadentity">createCadEntity()</h4>
+<h5 id="description_157">Description:</h5>
+<p>Creates instance of a Cad entity.</p>
+<h5 id="method-signatures_155">Method Signatures:</h5>
+<pre><code class="language-lua">createCadEntity(String name, Collection args)
+</code></pre>
+<p>Returns <code>object</code>.</p>
+<h4 id="explodeentity">explodeEntity()</h4>
+<h5 id="description_158">Description:</h5>
+<p>Explode CAD entity and returns a collection of entities</p>
+<h5 id="method-signatures_156">Method Signatures:</h5>
+<pre><code class="language-lua">explodeEntity(object entity)
+</code></pre>
+<h4 id="getblockreference">getBlockReference()</h4>
+<h5 id="description_159">Description:</h5>
+<p>Returns the BlockReference associated with the RC object.</p>
+<h5 id="method-signatures_157">Method Signatures:</h5>
+<pre><code class="language-lua">getBlockReference(IRailwayObject railwayObject)
+</code></pre>
+<h4 id="getclonesofnontextentitiesinblock">getClonesOfNonTextEntitiesInBlock()</h4>
+<h5 id="description_160">Description:</h5>
+<p>Return clones of the entities inside a block</p>
+<h5 id="method-signatures_158">Method Signatures:</h5>
+<pre><code class="language-lua">getClonesOfNonTextEntitiesInBlock(string blockName)
+</code></pre>
+<h4 id="getinnerblockreference">getInnerBlockReference()</h4>
+<h5 id="description_161">Description:</h5>
+<p>Returns the BlockReference with the given name inside the main BlockReference.</p>
+<h5 id="method-signatures_159">Method Signatures:</h5>
+<pre><code class="language-lua">getInnerBlockReference(IRailwayObject railwayObject, string blockName)
+</code></pre>
+<h4 id="getobjectsfromcadcollection">getObjectsFromCadCollection()</h4>
+<h5 id="description_162">Description:</h5>
+<p>Returns the entities inside a block</p>
+<h5 id="method-signatures_160">Method Signatures:</h5>
+<pre><code class="language-lua">getObjectsFromCadCollection(string blockName)
+</code></pre>
+<h4 id="getpolyline">getPolyline()</h4>
+<h5 id="description_163">Description:</h5>
+<p>Returns the Polyline associated with the RC object.</p>
+<h5 id="method-signatures_161">Method Signatures:</h5>
+<pre><code class="language-lua">getPolyline(IPlacedObjectBase railwayObject)
+</code></pre>
+<h4 id="loadlinetype">loadLineType()</h4>
+<h5 id="description_164">Description:</h5>
+<p>Loads a linetype. Either from DNA or AutoCAD linetype file.</p>
+<h5 id="method-signatures_162">Method Signatures:</h5>
+<pre><code class="language-lua">loadLineType(string lineTypeName)
+</code></pre>
+<h4 id="runentitymethodswithtransaction">runEntityMethodsWithTransaction()</h4>
+<h5 id="description_165">Description:</h5>
+<p>Creates a block containing given entities and puts it in the BlockTable</p>
+<h5 id="method-signatures_163">Method Signatures:</h5>
+<pre><code class="language-lua">runEntityMethodsWithTransaction(Entity entity, Collection propertiesAndValues)
+</code></pre>
+<h4 id="setentitypropertieswithtransaction">setEntityPropertiesWithTransaction()</h4>
+<h5 id="description_166">Description:</h5>
+<p>Creates a block containing given entities and puts it in the BlockTable</p>
+<h5 id="method-signatures_164">Method Signatures:</h5>
+<pre><code class="language-lua">setEntityPropertiesWithTransaction(Entity entity, Collection propertiesAndValues)
+</code></pre>
+<h3 id="deprecated_1">Deprecated</h3>
+<h4 id="createalignmentobject">createAlignmentObject()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#insertalignment">insertAlignment()</a> instead.</p>
+</div>
+<h5 id="description_167">Description:</h5>
+<p>Create an alignment from a HorizontalGeometry.</p>
+<h5 id="method-signatures_165">Method Signatures:</h5>
+<pre><code class="language-lua">createAlignmentObject(String type, String variant, List&lt;Point3D&gt; polyline3D)
+createAlignmentObject(String type, String variant, HorizontalGeometry horizontalGeometry)
+createAlignmentObject(String type, String variant, HorizontalGeometry horizontalGeometry, bool requireAudit = true, VerticalProfile verticalProfile = nil, CantProfile cantProfile = nil, SpeedProfile speedProfile = nil, MileageProfile mileageProfile = nil)
+</code></pre>
+<p>Returns <code>IAlignment</code>.</p>
+<h5 id="example_27">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment2(p2, d1, l1, 0, r)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+createAlignmentObject(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+</code></pre>
+<h4 id="createhorizontalprofile">createHorizontalProfile()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#createhorizontalgeometry">createHorizontalGeometry()</a> instead.</p>
+</div>
+<h5 id="description_168">Description:</h5>
+<p>Create horizontal geometry from horizontal segments.</p>
+<h5 id="method-signatures_166">Method Signatures:</h5>
+<pre><code class="language-lua">createHorizontalProfile(Collection&lt;Segment&gt; segments)
+</code></pre>
+<p>Returns <code>HorizontalGeometry</code>.</p>
+<h5 id="example_28">Example:</h5>
+<pre><code class="language-lua">local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment2(p2, d1, l1, 0, r)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalProfile({line, clothoid, curve})
+createAlignmentObject(rctype_Track, &quot;Enkle skinner og sviller med ballastprofil&quot;, horizontalGeometry)
+</code></pre>
+<h4 id="createpointobject">createPointObject()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#insertpointobject">insertPointObject()</a> instead.</p>
+</div>
+<h5 id="description_169">Description:</h5>
+<p>Creates a new railway object in the drawing and returns a reference to it.</p>
+<p>The object will have object type ‘rcType’. Its Variant will be deduced by RailCOMPLETE from its insertPointObjectOption string, being one of the possible drop-down options from the ribbon’s insert-point-object command. If no insertPointObjectOption string is given, then the top item from the ribbon’s dropdown list will apply.</p>
+<h5 id="method-signatures_167">Method Signatures:</h5>
+<pre><code class="language-lua">createPointObject(IAlignment alignment, String rcType, Double pos, Double distanceToAlignment, Boolean insertionSideIsLeft)
+createPointObject(IAlignment alignment, String rcType, Point3D insertionPoint)
+createPointObject(IAlignment alignment, String rcType, String insertPointObjectOptions, Double pos, Double distanceToAlignment, Boolean insertionSideIsLeft)
+createPointObject(IAlignment alignment, String rcType, String insertPointObjectOptions, Point3D insertionPoint)
+</code></pre>
+<p>Returns <code>IPlacedObjectBase</code>.</p>
+<h5 id="example_29">Example:</h5>
+<pre><code class="language-lua">--Example must be run in script context
+local p1 = getPoint3D(270.1883, 403.9474)
+local p2 = getPoint3D(634.415, 536.8692)
+local p3 = getPoint3D(671.898, 550.8322)
+local p4 = getPoint3D(844.4075, 637.7367)
+local p5 = getPoint3D(877.9371, 659.5475)
+local d1 = math.deg(0.349924146)
+local d2 = math.deg(0.369924153)
+local l1 = 40
+local l2 = 193.4645
+local r = 1000
+
+local line = createLineSegment(p1, p2)
+local clothoid = createClothoidSegment(p2, d1, l1, 0, math.sqrt(l1*r), true)
+local curve = createCurveSegment(p3, d2, l2, r)
+
+local horizontalGeometry = createHorizontalGeometry({line, clothoid, curve})
+local alignmentVariant = &quot;Enkle skinner og sviller med ballastprofil&quot; --NO-BN basic track variant
+local alignment = createAlignmentObject(rctype_Track, alignmentVariant, horizontalGeometry)
+
+local signalVariant = &quot;ERTMS E35 Stoppskilt, sidestilt&quot; --NO-BN ERTMS stop sign insertion option name
+local signal1 = createPointObject(alignment, rctype_EtcsEoA, signalVariant, 600, 4, false)
+</code></pre>
+<h4 id="getcontentsfromfile">getContentsFromFile()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#getfilefrompath or getfilefromprompt">getFileFromPath() or getFileFromPrompt()</a> instead.</p>
+</div>
+<h5 id="description_170">Description:</h5>
+<p>Returns the contents from a file.
+Returns dynamic ExpandoObject if FileType is Xml or Excel. Returns string if FileType is Txt.
+If the specified file does not exist then the user will be prompted to select one.</p>
+<h5 id="method-signatures_168">Method Signatures:</h5>
+<pre><code class="language-lua">getContentsFromFile(FileType fileType, String fileBrowserTitle, String defaultFileName = nil)
+getContentsFromFile(FileType fileType, String fileName)
+</code></pre>
+<p>Returns <code>ExpandoObject/String</code>.</p>
+<h4 id="getguid_1">getGUID()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#generateguid">generateGuid()</a> instead.</p>
+</div>
+<h5 id="description_171">Description:</h5>
+<p>Returns a GUID as string.</p>
+<h5 id="method-signatures_169">Method Signatures:</h5>
+<pre><code class="language-lua">getGUID()
+</code></pre>
+<p>Returns <code>String</code>.</p>
+<h4 id="runstaticmethodusingreflection">runStaticMethodUsingReflection()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#runexternallibraryfunction">runExternalLibraryFunction()</a> instead.</p>
+</div>
+<h5 id="description_172">Description:</h5>
+<p>Run a static method inside a type and return the result.</p>
+<h5 id="method-signatures_170">Method Signatures:</h5>
+<pre><code class="language-lua">runStaticMethodUsingReflection(String typeName, String methodName, Collection args)
+</code></pre>
+<p>Returns <code>object</code>.</p>
+<h4 id="setobjectid">setObjectId()</h4>
+<div class="admonition deprecated">
+<p class="admonition-title">Deprecated</p>
+<p>This function is deprecated. Use <a href="#setrcid">setRcId()</a> instead.</p>
+</div>
+<h5 id="description_173">Description:</h5>
+<p>Set new ID for RC object.</p>
+<h5 id="method-signatures_171">Method Signatures:</h5>
+<pre><code class="language-lua">setObjectId(IBaseObject obj, string id)
+</code></pre>
+              
+            </div>
+          </div><footer>
+    <div class="rst-footer-buttons" role="navigation" aria-label="Footer Navigation">
+        <a href="070-lua.html" class="btn btn-neutral float-left" title="Lua"><span class="icon icon-circle-arrow-left"></span> Previous</a>
+        <a href="080-luadebugger.html" class="btn btn-neutral float-right" title="Lua debugger">Next <span class="icon icon-circle-arrow-right"></span></a>
+    </div>
+
+  <hr/>
+
+  <div role="contentinfo">
+    <!-- Copyright etc -->
+      <p>&copy Railcomplete AS, 2025</p>
+  </div>
+
+  Built with <a href="https://www.mkdocs.org/">MkDocs</a> using a <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+</footer>
+          
+        </div>
+      </div>
+
+    </section>
+
+  </div>
+
+  <div class="rst-versions" role="note" aria-label="Versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    
+    
+      <span><a href="070-lua.html" style="color: #fcfcfc">&laquo; Previous</a></span>
+    
+    
+      <span><a href="080-luadebugger.html" style="color: #fcfcfc">Next &raquo;</a></span>
+    
+  </span>
+</div>
+    <script src="js/jquery-3.6.0.min.js"></script>
+    <script>var base_url = ".";</script>
+    <script src="js/theme_extra.js"></script>
+    <script src="js/theme.js"></script>
+      <script src="search/main.js"></script>
+    <script>
+        jQuery(function () {
+            SphinxRtdTheme.Navigation.enable(true);
+        });
+    </script>
+
+</body>
+</html>

--- a/.claude/references/080-luadebugger.html
+++ b/.claude/references/080-luadebugger.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html class="writer-html5" lang="en" >
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="author" content="Railcomplete AS" />
+      <link rel="shortcut icon" href="img/favicon.ico" />
+    <title>Lua debugger - RailCOMPLETE Reference Manual</title>
+    <link rel="stylesheet" href="css/theme.css" />
+    <link rel="stylesheet" href="css/theme_extra.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css" />
+        <link href="extra.css" rel="stylesheet" />
+    
+      <script>
+        // Current page data
+        var mkdocs_page_name = "Lua debugger";
+        var mkdocs_page_input_path = "080-luadebugger.md";
+        var mkdocs_page_url = null;
+      </script>
+    
+    <!--[if lt IE 9]>
+      <script src="js/html5shiv.min.js"></script>
+    <![endif]-->
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/lua.min.js"></script>
+      <script>hljs.highlightAll();</script> 
+</head>
+
+<body class="wy-body-for-nav" role="document">
+
+  <div class="wy-grid-for-nav">
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
+    <div class="wy-side-scroll">
+      <div class="wy-side-nav-search">
+<a href="./index.html" class="icon icon-home"> RailCOMPLETE Reference Manual</a><div role="search">
+  <form id ="rtd-search-form" class="wy-form" action="./search.html" method="get">
+      <input type="text" name="q" placeholder="Search docs" aria-label="Search docs" title="Type search term here" />
+  </form>
+</div>
+      </div>
+
+      <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Navigation menu">
+    
+		<div style="display: inline-block;">
+												
+					
+					<a href="./080-luadebugger.html">
+						<img style="height: 15px;" alt="English" src="./img/flags/en.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./fr/080-luadebugger.html">
+						<img style="height: 15px;" alt="Français" src="./img/flags/fr.png" />
+					</a>
+					
+				
+
+			</div>
+		<div style="display: inline-block;">
+						
+					
+					<a href="./de/080-luadebugger.html">
+						<img style="height: 15px;" alt="Deutsch" src="./img/flags/de.png" />
+					</a>
+					
+				
+
+			</div>
+		
+    
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="index.html">Welcome</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="010-gettingstarted.html">Getting started</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="020-mainfeatures.html">Main features</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="030-tipsandtricks.html">Tips and tricks</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="035-LinearReferencing.html">Linear Referencing</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="040-qa.html">Q&A</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="050-commands.html">RailCOMPLETE commands</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="060-export3d.html">Export 3D</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="070-lua.html">Lua</a>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="080-luacommands.html">Lua Functions</a>
+				</li>
+			</ul>
+			<ul class="current">
+				<li class="toctree-l1 current"><a class="reference internal current" href="080-luadebugger.html">Lua debugger</a>
+    <ul class="current">
+    <li class="toctree-l2"><a class="reference internal" href="#enabling-the-debugger">Enabling the debugger</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#notes">Notes</a>
+    </li>
+    <li class="toctree-l2"><a class="reference internal" href="#debugger-features">Debugger Features</a>
+        <ul>
+    <li class="toctree-l3"><a class="reference internal" href="#breakpoints">Breakpoints</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#variable-inspector">Variable Inspector</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#call-stack">Call Stack</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#watches">Watches</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#run">Run</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#step-into">Step Into</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#step-over">Step Over</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#step-out">Step Out</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#pause">Pause</a>
+    </li>
+    <li class="toctree-l3"><a class="reference internal" href="#stop">Stop</a>
+    </li>
+        </ul>
+    </li>
+    </ul>
+				</li>
+			</ul>
+			<ul>
+				<li class="toctree-l1"><a class="reference internal" href="090-classdiagrams.html">Class Diagrams</a>
+				</li>
+			</ul>
+      </div>
+    </div>
+    </nav>
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+      <nav class="wy-nav-top" role="navigation" aria-label="Mobile navigation menu">
+          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+          <a href="index.html">RailCOMPLETE Reference Manual</a>
+        
+      </nav>
+      <div class="wy-nav-content">
+        <div class="rst-content"><div role="navigation" aria-label="breadcrumbs navigation">
+  <ul class="wy-breadcrumbs">
+    <li><a href="index.html" class="icon icon-home" aria-label="Docs"></a></li>
+      <li class="breadcrumb-item active">Lua debugger</li>
+    <li class="wy-breadcrumbs-aside">
+    </li>
+  </ul>
+  <hr/>
+</div>
+          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+            <div class="section" itemprop="articleBody">
+              
+                <h1 id="lua-debugger">Lua debugger</h1>
+<p>The Lua debugger is a powerful tool designed to help developers write Lua scripts in RailCOMPLETE. Whether you're building complex Lua scripts or simply troubleshooting issues, this debugger provides a range of features to simplify the debugging process.</p>
+<p><strong>Features at a Glance:</strong></p>
+<ol>
+<li><strong>Breakpoints:</strong> Set breakpoints in your Lua script to pause execution at specific lines of code for inspection.</li>
+<li><strong>Variable Inspector:</strong> Examine the state of variables during execution to understand their values.</li>
+<li><strong>Call Stack:</strong> Visualize the call stack to track function calls and their contexts.</li>
+<li><strong>Watches:</strong> Monitor specific variables in real-time, enabling you to watch their values change as the program runs.</li>
+<li><strong>Run:</strong> Execute your script until it completes or encounters a breakpoint.</li>
+<li><strong>Step Into:</strong> Navigate into function calls to debug at a deeper level.</li>
+<li><strong>Step Over:</strong> Execute the current line and move to the next one without stepping into function calls.</li>
+<li><strong>Step Out:</strong> Finish executing the current function and return to the calling context.</li>
+<li><strong>Pause:</strong> Temporarily halt the execution of your Lua script.</li>
+<li><strong>Stop:</strong> Terminate the execution of the script entirely.</li>
+</ol>
+<p><img alt="Debugger overview" src="img/debugger_overview.png" /></p>
+<h2 id="enabling-the-debugger">Enabling the debugger</h2>
+<p>The debugger is accessible in the large Lua editor window, such as from "RC-EDITSCRIPT" or "RC-QUERYOBJECT". To activate the debugger, check the debugger checkbox.</p>
+<h2 id="notes">Notes</h2>
+<ul>
+<li>Only one script can execute at a time.</li>
+<li>The Lua timeout function is disabled in debugging mode, as you can manually stop the script with the stop button.</li>
+<li>If you're having trouble finding a specific variable in the variables tab, consider using a watch to have it easily accessible.</li>
+<li>Tooltips are available for most of the features in the debugger, making it easier to understand their functionality.</li>
+<li>Many actions within the debugger have convenient shortcuts, allowing for more efficient debugging.</li>
+</ul>
+<h2 id="debugger-features">Debugger Features</h2>
+<h3 id="breakpoints">Breakpoints</h3>
+<p>Breakpoints are markers placed at specific lines in your Lua script where you want to pause execution for inspection.</p>
+<p><strong>Usage:</strong></p>
+<ul>
+<li>Click in the line number margin of the code window to toggle breakpoints or check shortcut by right clicking in the code editor.</li>
+</ul>
+<p><img alt="Inserting new breakpoints" src="img/debugger_breakpoints.png" /></p>
+<h3 id="variable-inspector">Variable Inspector</h3>
+<p>The Variable Inspector allows you to inspect the values of variables at any point during script execution.</p>
+<p><strong>Usage:</strong></p>
+<ul>
+<li>Select a variable in the inspector to see its current value.</li>
+<li>Expand tables and userdata to view their internal structure.</li>
+</ul>
+<p><strong>Note:</strong></p>
+<ul>
+<li>The type column displays the equivalent C# type of the variable, not the Lua type.</li>
+</ul>
+<h3 id="call-stack">Call Stack</h3>
+<p>The Call Stack displays the sequence of function calls that led to the current execution point, helping you understand the program's flow.</p>
+<p><strong>Note:</strong></p>
+<ul>
+<li>When a function's last action is in the form of <code>return <em>function</em>(<em>args</em>)</code>, Lua performs a tail-call optimization. Lua does not need to return to the function and removes it from the stack and call stack.</li>
+</ul>
+<p><img alt="Tail call optimization" src="img/debugger_tail_call.png" /></p>
+<p><strong>Usage:</strong></p>
+<ul>
+<li>Double-click on stack frames to navigate to the call frame's line.</li>
+</ul>
+<h3 id="watches">Watches</h3>
+<p>Watches allow you to monitor the values of specific variables and evaluate expressions as the script executes, providing an easy way to monitor values without having to navigate the variables list. Watches with "break on change" checked will pause the script whenever the variable/expression returns a different value.</p>
+<p><strong>Usage:</strong></p>
+<ul>
+<li>Add variables to the watch list to monitor their values.</li>
+<li>Watches can be suspended to conserve processing resources that might otherwise slow down execution speed.</li>
+<li>Watches can be copied and pasted.</li>
+</ul>
+<p><img alt="Watches tab" src="img/debugger_watches.png" /></p>
+<p><strong>Note:</strong></p>
+<ul>
+<li>The watches are evaluated whenever the script pauses or for every line if "Break on change" is checked.</li>
+<li>Watches are also evaluated immediately whenever the expression is changed and the script is paused.</li>
+<li>Watches only have access to the variables available in the current evaluating scope.</li>
+<li>If a global variable is not used or declared in the current scope, the watches will not have access to the global scope.</li>
+<li>If an external local value is not used in the current scope, it will not be available.</li>
+<li>Exercise caution with more complex watch expressions, as assignments and executing functions in watches may impact the script's state.</li>
+</ul>
+<h3 id="run">Run</h3>
+<p>The "Run" feature allows you to execute your script until completion, until a breakpoint is encountered or until a watch with <code>break on change</code> changed value.</p>
+<h3 id="step-into">Step Into</h3>
+<p>"Step Into" takes you inside function calls, allowing you to inspect and debug them.</p>
+<h3 id="step-over">Step Over</h3>
+<p>"Step Over" executes the current line and moves to the next, without entering function calls.</p>
+<h3 id="step-out">Step Out</h3>
+<p>"Step Out" lets you finish executing the current function and return to the calling context.</p>
+<h3 id="pause">Pause</h3>
+<p>The "Pause" button halts script execution temporarily, allowing you to pause the script at any point.</p>
+<h3 id="stop">Stop</h3>
+<p>The "Stop" button terminates the execution of your Lua script entirely.</p>
+              
+            </div>
+          </div><footer>
+    <div class="rst-footer-buttons" role="navigation" aria-label="Footer Navigation">
+        <a href="080-luacommands.html" class="btn btn-neutral float-left" title="Lua Functions"><span class="icon icon-circle-arrow-left"></span> Previous</a>
+        <a href="090-classdiagrams.html" class="btn btn-neutral float-right" title="Class Diagrams">Next <span class="icon icon-circle-arrow-right"></span></a>
+    </div>
+
+  <hr/>
+
+  <div role="contentinfo">
+    <!-- Copyright etc -->
+      <p>&copy Railcomplete AS, 2025</p>
+  </div>
+
+  Built with <a href="https://www.mkdocs.org/">MkDocs</a> using a <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+</footer>
+          
+        </div>
+      </div>
+
+    </section>
+
+  </div>
+
+  <div class="rst-versions" role="note" aria-label="Versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    
+    
+      <span><a href="080-luacommands.html" style="color: #fcfcfc">&laquo; Previous</a></span>
+    
+    
+      <span><a href="090-classdiagrams.html" style="color: #fcfcfc">Next &raquo;</a></span>
+    
+  </span>
+</div>
+    <script src="js/jquery-3.6.0.min.js"></script>
+    <script>var base_url = ".";</script>
+    <script src="js/theme_extra.js"></script>
+    <script src="js/theme.js"></script>
+      <script src="search/main.js"></script>
+    <script>
+        jQuery(function () {
+            SphinxRtdTheme.Navigation.enable(true);
+        });
+    </script>
+
+</body>
+</html>

--- a/.claude/skills/lua-properties/SKILL.md
+++ b/.claude/skills/lua-properties/SKILL.md
@@ -1,0 +1,693 @@
+---
+name: lua-properties
+description: Guide for writing Lua-controlled property formulas in DNA XML files -- LuaFunction declarations, LuaExpression bindings, TextPosition/TextRotation formulas, and model checks
+---
+
+# Lua Controlled Properties Guide
+
+This guide covers writing Lua code in the DNA context: reusable `<LuaFunction>` declarations, inline `<LuaExpression>` property formulas, and TextPosition/TextRotation formulas. All code runs in a sandboxed per-object context where `this` properties are available as globals.
+
+$ARGUMENTS
+
+For the full API reference, see `.claude/documentation/080-luacommands.html`. For Lua language basics, see `.claude/documentation/070-lua.html`.
+
+## Overview
+
+Lua-controlled properties let DNA authors compute object property values dynamically. The Lua code runs inside a sandbox with ~88 API functions available. Each evaluation has access to the current railway object (`this`) whose properties are exposed as global variables (e.g., `RcType`, `Variant`, `Alignment`, `Mileage`, `dir`, `geoCoord`).
+
+There are three XML elements that embed Lua in DNA files:
+
+| Element | Purpose |
+|---------|---------|
+| `<LuaFunction>` | Declare a reusable named function |
+| `<LuaExpression>` | Bind a Lua formula to a specific property |
+| TextPosition/TextRotation | Special formulas for text attribute placement |
+
+## DNA XML Structure
+
+### LuaFunction — Reusable Function Declarations
+
+```xml
+<LuaFunction Name="PREFIX_category_functionName()"
+             ReturnType="String"
+             HideFromUser="false"
+             Description="Human-readable description of what this function computes.">
+    <Signature>String PREFIX_category_functionName()</Signature>
+    <Signature>String PREFIX_category_functionName(IBaseObject obj)</Signature>
+    <Formula>
+        function PREFIX_category_functionName(obj)
+            obj = obj or this
+            -- implementation
+            return value
+        end
+    </Formula>
+</LuaFunction>
+```
+
+**Attributes:**
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `Name` | Yes | Function name with `()` suffix |
+| `ReturnType` | Yes | `String`, `Double`, `Boolean`, `Int`, `Tuple`, `Collection`, `ObjectRef` |
+| `Description` | Yes | Tooltip shown to users |
+| `HideFromUser` | No | `"true"` hides from intellisense (for internal helpers) |
+
+**Child elements:**
+
+| Element | Purpose |
+|---------|---------|
+| `<Signature>` | One or more method signatures for tooltips |
+| `<Formula>` | The Lua function body (no CDATA wrapper needed) |
+
+### LuaExpression — Property Formula Binding
+
+Binds a Lua expression to a property by name:
+
+```xml
+<!-- Simple property formula -->
+<LuaExpression Name="PropertyName">
+    <Formula>PREFIX_category_functionName()</Formula>
+</LuaExpression>
+
+<!-- 3D geometry binding -->
+<LuaExpression Name="Geometry3D_0.Name">
+    <Formula>_myObject_Geometry3DName()</Formula>
+</LuaExpression>
+<LuaExpression Name="Geometry3D_0.Offset.Z">
+    <Formula>_myObject_OffsetZ()</Formula>
+</LuaExpression>
+
+<!-- Model check formula -->
+<LuaExpression Name="mc_SomeCheck" IsModelCheck="true">
+    <Formula>PREFIX_category_chkSomething()</Formula>
+</LuaExpression>
+```
+
+### TextPosition and TextRotation Formulas
+
+These control the placement of text attributes in the drawing:
+
+```xml
+<!-- Position returns (acsX, acsY) tuple -->
+<LuaExpression Name="TextAttribute_LABEL.Position">
+    <Formula>_myObject_LabelTextPosition(20, 0)</Formula>
+</LuaExpression>
+
+<!-- Rotation returns angle in decimal degrees -->
+<LuaExpression Name="TextAttribute_LABEL.Rotation">
+    <Formula>_myObject_LabelTextRotation()</Formula>
+</LuaExpression>
+
+<!-- Simple position using built-in flip helper -->
+<LuaExpression Name="TextAttribute_NAME.Position">
+    <Formula>RC__flipAcsTuple(20, 0)</Formula>
+</LuaExpression>
+```
+
+## Naming Conventions
+
+### Function Name Prefixes
+
+Use a discipline-based prefix matching the DNA administration:
+
+```
+NOBN_sig_    Signalling (NO-BN)
+NOBN_ocs_    Overhead Catenary System (NO-BN)
+NOBN_trk_    Track (NO-BN)
+NOBN_com_    Common/shared (NO-BN)
+FRSR_sig_    Signalling (FR-SR)
+RC__         RailCOMPLETE general library functions
+```
+
+### Function Name Patterns
+
+```
+PREFIX_category_getSomething()     -- Getter: returns a value
+PREFIX_category_chkSomething()     -- Model check: returns (message, objects, status)
+_ObjectName_OffsetZ()              -- Private helper (leading underscore)
+RC__toInt()                        -- Utility function
+```
+
+### Template Pattern
+
+Use this template from `_NO-BN-TemplateFunctionDeclaration.xml` as a starting point:
+
+```xml
+<LuaFunction Name="PREFIX_category_myFunction()"
+             ReturnType="String"
+             HideFromUser="false"
+             Description="Describe what the function computes.">
+    <Signature>String PREFIX_category_myFunction()</Signature>
+    <Signature>String PREFIX_category_myFunction(IBaseObject obj)</Signature>
+    <Formula>
+        function PREFIX_category_myFunction(obj)
+            obj = obj or this
+            -- implementation here
+            return result
+        end
+    </Formula>
+</LuaFunction>
+```
+
+## The `this` Object
+
+In property formula context, the current railway object is `this`. Its properties are available as global variables:
+
+### Identity and Type
+```lua
+RcType          -- e.g., "JBTSA_SIG Signal" (object type string)
+Variant         -- e.g., "3-lys hovedsignal" (variant/subtype)
+name            -- Display name
+code            -- Identifier code
+id              -- Unique GUID string
+Discipline      -- Discipline category
+```
+
+### Position and Alignment
+```lua
+Alignment       -- Parent alignment object reference (nil if unplaced)
+Mileage         -- Distance along alignment [m]
+ReferenceMileage -- Mileage on reference alignment
+DistanceToAlignment -- Lateral distance [m]
+LateralOffset   -- Perpendicular offset
+VerticalOffset  -- Vertical elevation relative to alignment
+geoCoord        -- World coordinates: geoCoord.X, geoCoord.Y, geoCoord.Z
+SymbolOffset    -- Symbol display offset: SymbolOffset.X, SymbolOffset.Y
+AlignmentTangent -- Alignment tangent angle at object position [radians]
+```
+
+### Direction and Side
+```lua
+dir             -- "up", "down", "both", "none", or "unknown"
+RightSided      -- true if on right side of alignment
+LeftSided       -- true if on left side
+MileageIncreasesTowardsLeft -- true if km increases leftward in UCS
+```
+
+### Drawing Properties
+```lua
+Layer           -- Layer name (e.g., "@@" prefix means historic)
+Color           -- Color value
+Derogation      -- Derogation state: "REQUESTED", "GRANTED", etc.
+```
+
+### Formula Access
+```lua
+LuaExpressions  -- Collection of all formula results on this object
+                -- Each has .IsModelCheck, .Symbol, .Value properties
+```
+
+## Key API Patterns
+
+### Object Discovery
+
+```lua
+-- Related objects (returns collection + count, 0-INDEXED)
+local r, n = getRelatedObjects("RelationType")
+local r, n = getRelatedObjects("RelationType", sourceObj)
+if n > 0 then
+    local first = r[0]  -- 0-indexed!
+end
+
+-- Topology: next/previous along alignment
+local nextSignal = getUpObject(rctype_Signal)      -- next in "up" direction
+local prevSignal = getDownObject(rctype_Signal)     -- next in "down" direction
+
+-- Nearby objects (2D distance search)
+local poles, nPoles = getNearbyPointObjects2D(50, rctype_OcsPole)
+local tracks = getNearbyAlignments(rctype_Track)
+```
+
+### Alignment Information
+
+```lua
+local ai = getAlignmentInfo()               -- at this object's position
+local ai = getAlignmentInfo(alignmentId)    -- on a specific alignment
+
+-- Available fields:
+ai.Mileage                    -- Distance along alignment [m]
+ai.Elevation                  -- Vertical elevation [m]
+ai.Tangent                    -- Direction vector
+ai.Cant                       -- Superelevation [mm]
+ai.CantRotation               -- "CW" or "CCW"
+ai.DistanceToAlignment        -- Lateral distance [m]
+ai.Gradient                   -- Grade percentage
+ai.CurveRadius                -- Radius of curvature [m]
+ai.NormalProjectionExists     -- Can project to alignment?
+ai.LinearAddress.DistanceAlong -- Position along alignment
+```
+
+### Distance Calculations
+
+```lua
+local dist = getDistance(obj1, obj2)            -- along alignment
+local dist2d = RC__getDistance2D(point1, point2) -- Euclidean 2D
+local dist3d = RC__getDistance3D(point1, point2) -- Euclidean 3D
+```
+
+### Collections
+
+```lua
+-- Filter (returns new 0-indexed collection)
+local signals = collection:filter(function(x)
+    return x.RcType == rctype_Signal and x.code:match("Hs")
+end)
+
+-- Get length
+local count = getCollectionLength(collection)
+
+-- Union multiple collections
+local combined = getUnionOfCollections({collection1, collection2})
+
+-- Sort: convert to Lua table, sort, convert back
+local t = {}
+for i = 0, n - 1 do
+    table.insert(t, items[i])
+end
+table.sort(t, function(a, b) return a.Mileage < b.Mileage end)
+local sorted = getCollectionFromTable(t)
+
+-- Order directly
+local ordered = orderByAscending(collection, function(x) return x.Mileage end)
+```
+
+### Properties
+
+```lua
+local value = getPropertyValue("PropertyName")
+local value = obj:getPropertyValue("PropertyName")
+local displayName = getEnumDisplayName("EnumValue", "EnumTypeName")
+local propName = fromDisplayName("Display Name")
+```
+
+### Coordinates and Vectors
+
+```lua
+local p = getPoint3D(x, y, z)
+local p = getPoint3D(x, y)      -- z defaults to 0
+
+-- Vector operations
+local modulus = getVectorModulus(v)
+local normalized = getVectorNormalized(v)
+local dot = getVectorDotProduct(v1, v2)
+local angle = getVectorAngleDD(v1, v2)  -- in decimal degrees
+```
+
+### Block Images
+
+```lua
+local img = get3DBlockImage("BlockName")
+local img = getBlockImage("2DBlockName")
+local names = getBlockNames("Pattern*")
+local bounds = getBlockBounds("BlockName")
+```
+
+### Include Files
+
+```lua
+includeLuaFile("path/to/file.lua")  -- relative to DNA folder
+```
+
+## ACS to WCS Coordinate Conversion
+
+The Alignment Coordinate System (ACS) uses lateral/longitudinal offsets relative to the alignment. World Coordinate System (WCS) uses absolute X/Y coordinates. Conversion is essential for TextPosition formulas.
+
+```lua
+-- ACS → WCS
+local wcsX, wcsY = RC__AcsToWcs(lateralOffset, longitudinalOffset, angleDeg, obj)
+
+-- WCS → ACS
+local acsX, acsY = RC__WcsToAcs(wcsX, wcsY, angleDeg, obj)
+
+-- Flip ACS tuple based on object side and direction
+local flippedLat, flippedLong = RC__flipAcsTuple(lateralOffset, longitudinalOffset, obj)
+-- Flips lateral based on RightSided/LeftSided
+-- Flips longitudinal based on dir (up/down)
+```
+
+## Return Values and Status Symbols
+
+### Simple Returns
+
+```lua
+return value                   -- just a value
+return value, _info("message") -- value with tooltip info
+```
+
+### Model Check Returns
+
+Model check functions (bound via `IsModelCheck="true"`) return status indicators:
+
+```lua
+return "OK - Everything checks out.", _ok           -- green checkmark
+return "WARNING - Marginal distance.", _warning     -- yellow triangle
+return "ERROR - Distance too short.", _error        -- red X
+return "UNFINISHED - Missing data.", _unfinished    -- orange square
+
+-- With related objects (highlighted in drawing)
+return "ERROR - Too close.", {relatedObj}, _error
+
+-- With info tooltip
+return message, {relatedObj}, _error, _info("Expected 3.0m minimum")
+```
+
+### Symbol Constants
+
+```lua
+_ok          -- green checkmark (success)
+_warning     -- yellow triangle (warning)
+_error       -- red X (error)
+_unfinished  -- orange square (incomplete)
+_noSymbol    -- no visual indicator
+_info(msg)   -- creates a tooltip message
+```
+
+## Real Examples
+
+### Simple Property Formula — Signal Name
+
+```xml
+<LuaFunction Name="NOBN_sig_getSignalNumber()"
+             ReturnType="String"
+             Description="Returns the signal number derived from code.">
+    <Signature>String NOBN_sig_getSignalNumber()</Signature>
+    <Formula>
+        function NOBN_sig_getSignalNumber(obj)
+            obj = obj or this
+            local c = obj:getPropertyValue("code")
+            if c == nil or c == "" then
+                return "", _info("No code set")
+            end
+            if c:match("%d+%D+") then
+                return c:match("%d+%D+"):match("%d+")
+            end
+            return c
+        end
+    </Formula>
+</LuaFunction>
+```
+
+### Model Check — Balise Distance
+
+```xml
+<LuaFunction Name="NOBN_sig_chkBaliseDistance()"
+             ReturnType="Tuple"
+             Description="Checks distance to next balise in same direction.">
+    <Signature>Tuple NOBN_sig_chkBaliseDistance()</Signature>
+    <Formula>
+        function NOBN_sig_chkBaliseDistance(balise)
+            balise = balise or this
+            if balise.Alignment == nil then
+                return "UNFINISHED - Missing alignment.", _unfinished
+            end
+
+            local nextBalise = getDownObject(balise.RcType)
+            if nextBalise == nil then
+                return "OK - No balise within reach.", _ok
+            end
+
+            local dist = getDistance(balise, nextBalise)
+            local t = string.format("%.03f", dist)
+
+            if dist < 2.35 then
+                return t .. ": ERROR - Fields may merge.", {nextBalise}, _error
+            elseif dist < 2.8 then
+                return t .. ": WARNING - Outside tolerance.", {nextBalise}, _warning
+            else
+                return t .. ": OK - Within tolerance.", {nextBalise}, _ok
+            end
+        end
+    </Formula>
+</LuaFunction>
+
+<!-- Bound as a model check -->
+<LuaExpression Name="mc_BaliseDistance" IsModelCheck="true">
+    <Formula>NOBN_sig_chkBaliseDistance()</Formula>
+</LuaExpression>
+```
+
+### TextPosition — Midpoint Between Two Poles
+
+```xml
+<LuaFunction Name="_JBTEH_MAS_SpanlengthTextPosition()"
+             ReturnType="Tuple"
+             HideFromUser="true"
+             Description="Position span length text at midpoint between this pole and the next.">
+    <Signature>Tuple _JBTEH_MAS_SpanlengthTextPosition(Double LateralOffset, Double LongitudinalOffset)</Signature>
+    <Formula>
+        function _JBTEH_MAS_SpanlengthTextPosition(LateralOffset, LongitudinalOffset, obj)
+            obj = obj or this
+            LateralOffset = LateralOffset or 0
+            LongitudinalOffset = LongitudinalOffset or 0
+
+            local r, n = getRelatedObjects(rel_OcsPole_HasNext_OcsPole)
+            if n == 0 then
+                return 0, 0
+            end
+
+            local target = r[0]
+
+            -- WCS coordinates of display points
+            local startX = obj.geoCoord.X + obj.SymbolOffset.X
+            local startY = obj.geoCoord.Y + obj.SymbolOffset.Y
+            local endX = target.geoCoord.X + target.SymbolOffset.X
+            local endY = target.geoCoord.Y + target.SymbolOffset.Y
+
+            -- Midpoint in WCS, then convert to ACS
+            local wcsX = obj.SymbolOffset.X + (endX - startX) / 2 + LongitudinalOffset
+            local wcsY = obj.SymbolOffset.Y + (endY - startY) / 2 - LateralOffset
+            local acsX, acsY = -wcsY, wcsX
+
+            return RC__round(acsX, 3), RC__round(acsY, 3)
+        end
+    </Formula>
+</LuaFunction>
+
+<LuaExpression Name="TextAttribute_SPENNLENGDE.Position">
+    <Formula>_JBTEH_MAS_SpanlengthTextPosition(20, 0)</Formula>
+</LuaExpression>
+```
+
+### TextRotation — Angle Between Display Points
+
+```xml
+<LuaFunction Name="_JBTEH_MAS_SpanlengthTextRotation()"
+             ReturnType="Double"
+             HideFromUser="true"
+             Description="Rotate span length text to follow the line between poles.">
+    <Signature>Double _JBTEH_MAS_SpanlengthTextRotation()</Signature>
+    <Formula>
+        function _JBTEH_MAS_SpanlengthTextRotation()
+            local r, n = getRelatedObjects(rel_OcsPole_HasNext_OcsPole)
+            if n == 0 then
+                return AlignmentTangent
+            end
+
+            local target = r[0]
+            local startX = geoCoord.X + SymbolOffset.X
+            local startY = geoCoord.Y + SymbolOffset.Y
+            local endX = target.geoCoord.X + target.SymbolOffset.X
+            local endY = target.geoCoord.Y + target.SymbolOffset.Y
+
+            local angle = math.deg(math.atan(endY - startY, endX - startX))
+            return angle + (MileageIncreasesTowardsLeft and 180 or 0)
+        end
+    </Formula>
+</LuaFunction>
+```
+
+### Collection Filtering — Balise Position in Group
+
+```xml
+<LuaFunction Name="_JBTSA_ETB_positionInGroup()"
+             ReturnType="Int"
+             HideFromUser="true"
+             Description="Returns the ordinal position of this balise within its group.">
+    <Signature>Int _JBTSA_ETB_positionInGroup()</Signature>
+    <Formula>
+        function _JBTSA_ETB_positionInGroup(balise)
+            balise = balise or this
+            local groups, nGroups = balise:getRelatedObjects(rel_EtcsBalise_BelongsTo_EtcsBaliseGroup)
+
+            if nGroups == 0 then
+                return "?", _info("Connect balise to its group.")
+            end
+
+            local bg = groups[0]
+            local balises, nBalises = bg:getRelatedObjects(rel_EtcsBaliseGroup_Contains_EtcsBalise)
+
+            if nBalises == 1 then
+                return 0
+            end
+
+            -- Sort by position along alignment
+            local t = {}
+            for i = 0, nBalises - 1 do
+                table.insert(t, {
+                    id = balises[i].id,
+                    pos = balises[i]:getAlignmentInfo().LinearAddress.DistanceAlong
+                })
+            end
+            table.sort(t, function(a, b)
+                local sgn = (bg.dir == "up" and 1 or -1)
+                return sgn * a.pos < sgn * b.pos
+            end)
+
+            t = getCollectionFromTable(t)
+            for i = 0, nBalises - 1 do
+                if balise.id == t[i].id then
+                    return i, _info("Position #" .. i .. " in direction '" .. bg.dir .. "'")
+                end
+            end
+        end
+    </Formula>
+</LuaFunction>
+```
+
+### Symbol Frame Logic — Variant and Model Check Aggregation
+
+```lua
+function NOBN_com_setSymbolFrame()
+    local language = 2  -- 1:EN, 2:NO, 3:FR, 4:DE
+    local frames = {
+        UNFINISHED = {"Unfinished", "Unfinished", "Incomplet", "Unvollstaendig"},
+        WARNING    = {"Warning",    "Warning",    "Avertissement", "Warnung"},
+        ERROR      = {"Error",      "Error",      "Erreur",    "Fehler"},
+        REQUESTED  = {"Requested",  "Requested",  "Demandee",  "Nachgefragt"},
+        GRANTED    = {"Granted",    "Granted",    "Accordee",  "Zugesagt"},
+    }
+
+    if tostring(Layer):sub(1, 2) == "@@" then
+        return frames.HISTORIC[language]
+    end
+
+    local modelChecks = LuaExpressions:filter(function(x) return x.IsModelCheck end)
+
+    if modelChecks:filter(function(x) return x.Symbol == "_unfinished" end).Count > 0 then
+        return frames.UNFINISHED[language]
+    elseif Derogation == "REQUESTED" then
+        return frames.REQUESTED[language]
+    elseif Derogation == "GRANTED" then
+        return frames.GRANTED[language]
+    elseif modelChecks:filter(function(x) return x.Symbol == "_error" end).Count > 0 then
+        return frames.ERROR[language]
+    elseif modelChecks:filter(function(x) return x.Symbol == "_warning" end).Count > 0 then
+        return frames.WARNING[language]
+    else
+        return ""
+    end
+end
+```
+
+## Common Pitfalls
+
+### 0-Indexed Collections
+RailCOMPLETE collections from `getRelatedObjects()`, `filter()`, etc. are **0-indexed**. Lua tables created with `table.insert()` are 1-indexed.
+
+```lua
+-- WRONG
+local items, n = getRelatedObjects(rel)
+for i = 1, n do         -- misses index 0!
+    local item = items[i]
+end
+
+-- CORRECT
+for i = 0, n - 1 do
+    local item = items[i]
+end
+```
+
+### Nil Checks Before Property Access
+Always check that alignment and related objects exist before accessing properties:
+
+```lua
+-- WRONG
+local elevation = getAlignmentInfo().Elevation
+
+-- CORRECT
+if Alignment == nil then
+    return "UNFINISHED - No alignment.", _unfinished
+end
+local ai = getAlignmentInfo()
+if ai == nil or RC__isNan(ai.Elevation) then
+    return 0, _info("Missing elevation")
+end
+```
+
+### Default Parameters
+Always default `obj` to `this`:
+
+```lua
+function myFunction(obj)
+    obj = obj or this    -- essential!
+    -- ...
+end
+```
+
+### String Comparisons
+Use `tostring()` when comparing property values that might not be strings:
+
+```lua
+if tostring(Layer):sub(1, 2) == "@@" then
+```
+
+### String Formatting
+Use `string.format()` for numeric formatting:
+
+```lua
+string.format("%.3f", value)    -- 3 decimal places
+string.format("%04d", number)   -- 4-digit zero-padded
+```
+
+### Multi-line Text
+Use `\\P` for line breaks in MText display values:
+
+```lua
+return "Line 1\\PLine 2\\PLine 3"
+```
+
+## Common Object Type Constants
+
+```lua
+rctype_Signal                    rctype_Track
+rctype_EtcsBalise                rctype_EtcsBaliseGroup
+rctype_Balise                    rctype_BaliseGroup
+rctype_OcsPole                   rctype_Cantilever
+rctype_ContactWire               rctype_Switch
+rctype_WireTensioningBalancer    rctype_InnerRailAndInsulation
+```
+
+## Common Relation Type Constants
+
+```lua
+rel_Signal_Has_BaliseGroup
+rel_EtcsBalise_BelongsTo_EtcsBaliseGroup
+rel_EtcsBaliseGroup_Contains_EtcsBalise
+rel_OcsPole_HasNext_OcsPole
+rel_OcsPole_Has_Cantilever
+rel_Cantilever_Holds_ContactWire
+rel_CantileverOrWtb_HasNext_CantileverOrWtb
+rel_Label_AppliesTo_Anything
+```
+
+## Utility Functions Reference
+
+```lua
+RC__toInt(x)                     -- convert to integer
+RC__round(x, decimals)           -- round to N decimal places
+RC__isNan(x)                     -- check if NaN
+RC__identify(obj)                -- get name, code, or id (best available)
+RC__sub(s, i, j)                 -- multi-byte safe substring
+RC__flipAcsTuple(lat, long, obj) -- flip offsets by side/direction
+RC__AcsToWcs(lat, long, deg, obj)-- ACS to WCS conversion
+RC__WcsToAcs(x, y, deg, obj)    -- WCS to ACS conversion
+RC__getDistance2D(p1, p2)        -- Euclidean 2D distance
+RC__getDistance3D(p1, p2)        -- Euclidean 3D distance
+RC__isMemberOf(coll, item)       -- membership test
+```
+
+## Documentation Reference
+
+- **Full API reference**: `.claude/documentation/080-luacommands.html` — all ~88 object-level functions with signatures, descriptions, and examples
+- **Lua language tutorial**: `.claude/documentation/070-lua.html` — Lua syntax, types, operators, control structures

--- a/.claude/skills/lua-scripting/SKILL.md
+++ b/.claude/skills/lua-scripting/SKILL.md
@@ -1,0 +1,924 @@
+---
+name: lua-scripting
+description: Guide for writing standalone Lua scripts in DNA repositories -- user interaction, object creation, file I/O, AutoCAD commands, and CAD entity drawing
+---
+
+# Lua Scripts Guide
+
+This guide covers writing standalone Lua scripts that execute actions in the drawing. Scripts run in the `RunScriptLuaContext` which provides all object-level API functions plus ~60 script-only functions for user interaction, object manipulation, file I/O, and CAD entity creation.
+
+$ARGUMENTS
+
+For the full API reference, see `.claude/documentation/080-luacommands.html`. For RC commands, see `.claude/documentation/050-commands.html`. For debugger usage, see `.claude/documentation/080-luadebugger.html`.
+
+## Overview
+
+Scripts differ from property formulas in several ways:
+
+| Aspect | Property Formulas | Scripts |
+|--------|-------------------|---------|
+| Context | `LuaContext` (sandboxed, per-object) | `RunScriptLuaContext` (full drawing access) |
+| Execution | Synchronous, triggered on property eval | Async, user-initiated |
+| `this` | Current railway object | Not available (select objects explicitly) |
+| Scope | Read-only computation | Create, modify, delete objects |
+| API | ~88 object-level functions | All object-level + ~60 script-only functions |
+
+## Script Structure
+
+### Standard Template
+
+```lua
+--[[
+    Script Title
+    ============
+    Brief description of what the script does.
+
+    2025-01-15 v1.0 AUTHOR Created
+    2025-03-20 v1.1 AUTHOR Added feature X
+--]]
+
+-- Helper functions
+function writeln(t) write((t or "") .. "\n") end
+function show(t) writeln(t) askForKeyword(t, {"OK"}) end
+
+-- Constants
+local _HEADER_ = "Script Title"
+
+-- Display initial message
+show([[
+    Script Title
+    ============
+    Description of usage, inputs, outputs.
+
+    - Step 1: Select a file
+    - Step 2: Select a template object
+    - Step 3: Objects are created
+]])
+
+-- Main logic
+-- ...
+```
+
+### Helper Functions
+
+**writeln** — output with newline:
+```lua
+function writeln(t) write((t or "") .. "\n") end
+```
+
+**writeln with status symbol**:
+```lua
+function writeln(t, symbol) write((t or "") .. "\n", symbol or _noSymbol) end
+```
+
+**show** — modal dialog:
+```lua
+function show(t) writeln(t) askForKeyword(t, {"OK"}) end
+```
+
+**show with abort option**:
+```lua
+function show(t)
+    writeln(t)
+    local r = askForKeyword(t, {"OK", "Abort"})
+    if r == "Abort" then Halt() end
+end
+```
+
+### Constants
+
+```lua
+local _HEADER_ = "Script Title"
+local _VERSION_ = "1.0"
+local _DEBUG_ = false
+local _YES_ = "Yes"
+local _NO_ = "No"
+local _HELP_ = "Help"
+local _TERMINATE_ = "Terminate"
+```
+
+## User Interaction
+
+### askForKeyword — Multiple Choice Dialog
+
+```lua
+local option = askForKeyword("Select action:", {"Option 1", "Option 2", "Abort"})
+
+-- With header/title
+local option = askForKeyword("Choose format:", {"Excel", "CSV", "JSON"}, _HEADER_)
+```
+
+**Menu loop pattern:**
+```lua
+local option
+repeat
+    option = askForKeyword("Select action:", {"Insert", "Help", "Exit"}, _HEADER_)
+
+    if option == "Help" then
+        show("Help text here...")
+    elseif option == "Insert" then
+        -- do work
+    end
+until option == "Exit" or option == nil
+```
+
+### askForObject / askForPointObject — Object Selection
+
+```lua
+local obj = askForObject("Select an object in the drawing")
+local pointObj = askForPointObject("Select a point object")
+
+-- Multiple objects
+local objects = askForPointObjects("Select point objects (press Enter when done)")
+```
+
+### askForAlignment — Alignment Selection
+
+```lua
+local alignment = askForAlignment("Select reference alignment: ")
+
+-- Get the underlying CAD polyline
+local polyline = cadInterface.getCadEntityFromRcObject(alignment)
+```
+
+### askForPoint — Point Picking
+
+**Important**: `askForPoint()` throws an exception if the user presses Escape. Wrap in a nil check if cancellation should be graceful:
+
+```lua
+local point = askForPoint("Click insertion point:")
+if not point then return end
+```
+
+### askForDouble / askForInteger / askForString — Value Input
+
+```lua
+local radius = askForDouble("Enter search radius [m]:")
+local count = askForInteger("Enter number of objects:")
+local name = askForString("Enter a name:")
+
+-- With default value
+local mileage = askForDouble("Enter start mileage [m]:", 0)
+```
+
+### askForFileName / askForFolderName — File/Folder Dialogs
+
+```lua
+local filename = askForFileName("Select Excel file with coordinates")
+local folder = askForFolderName("Select output folder")
+
+-- Optional file (Escape to skip)
+local optionalFile = askForFileName("Select file (Escape to skip)")
+if optionalFile then
+    -- process file
+end
+```
+
+### showMessage — Display Message
+
+```lua
+showMessage("Operation completed successfully.")
+```
+
+## Object Creation and Manipulation
+
+### Alignment Creation
+
+```lua
+-- From geometry segments
+local segments = {}
+table.insert(segments, createLineSegment(p1, p2))
+table.insert(segments, createCurveSegment2(p2, directionDeg, p3))
+local geometry = createHorizontalGeometry(segments)
+local track = createAlignmentObject(rctype_Track, "Variant Name", geometry)
+
+-- From coordinate points (implicit geometry)
+local points = {getPoint3D(x1, y1, z1), getPoint3D(x2, y2, z2), getPoint3D(x3, y3, z3)}
+local track = createAlignmentObject(rctype_Track, "Variant Name", points)
+
+-- Set properties after creation
+track.code = "="        -- reset formula first
+track.code = "V1"       -- then assign value
+track.name = track.name -- force save and update derived fields
+```
+
+### Geometry Segments
+
+```lua
+-- Straight line
+local line = createLineSegment(startPoint, endPoint)
+
+-- Circular arc (from start point, direction, end point)
+local arc = createCurveSegment2(startPoint, directionDegrees, endPoint)
+
+-- Clothoid/spiral
+local clothoid = createClothoidSegment(startPoint, directionDegrees, length, startRadius, A, isPositive)
+
+-- Combine into horizontal geometry
+local geometry = createHorizontalGeometry(segments)
+```
+
+### Point Object Creation
+
+```lua
+-- createPointObject(alignment, rctype, variant, position, distFromAlignment, leftSide)
+local signal = createPointObject(
+    track,
+    rctype_Signal,
+    "Signal classique, cible ACFH",
+    pos,
+    3.5,    -- distance from alignment [m]
+    true    -- left side of track
+)
+
+-- insertPointObject (modern, simpler API)
+local obj = insertPointObject(alignment, rctype, variant, position)
+local obj = insertPointObject(alignment, rctype, position)  -- no variant
+```
+
+### Property Assignment
+
+**Direct assignment:**
+```lua
+signal.name = "Signal A"
+signal.DrawTail = true
+signal.dir = "down"
+object.VerticalOffset = 5.5
+```
+
+**Formula binding pattern** — reset formula, then assign:
+```lua
+obj.name = "="          -- remove any existing formula
+obj.name = "New Name"   -- assign concrete value
+
+obj.VerticalOffset = "=" -- remove elevation formula
+obj.VerticalOffset = z   -- assign explicit value
+```
+
+**Force save/update:**
+```lua
+alignment.name = alignment.name  -- triggers save and recalculation of derived fields
+```
+
+### Relations
+
+```lua
+setRelation(sourceObj, targetObj, "RelationType")
+```
+
+### Profile Creation
+
+```lua
+-- Vertical profile
+local events = {}
+table.insert(events, createVerticalEvent(pos1, elevation1))
+table.insert(events, createVerticalEvent(pos2, elevation2))
+createVerticalProfile(alignment, events)
+
+-- Cant profile
+local cantEvents = {}
+table.insert(cantEvents, createCantEvent(pos, cantValue))
+createCantProfile(alignment, cantEvents)
+
+-- Speed profile
+local speedEvents = {}
+table.insert(speedEvents, createSpeedEvent(pos, speedKmh))
+createSpeedProfile(alignment, speedEvents)
+
+-- Mileage profile
+local mileageEvents = {}
+table.insert(mileageEvents, createMileageEvent(pos, mileageValue))
+createMileageProfile(alignment, mileageEvents)
+
+-- Update vertical data from point list
+updateAlignmentVerticalData(alignment, table.select(pointList, function(p)
+    return getPoint3D(p.X, p.Y, p.Z)
+end))
+```
+
+### Deletion
+
+```lua
+eraseObject(obj)
+```
+
+## File I/O
+
+### Excel Reading
+
+```lua
+-- 1. Open file
+local filename = askForFileName("Select Excel file")
+local file = getContentsFromFile(FileType.Excel, "", filename)
+
+-- 2. Get sheet names
+local sheets = getExpandoObjectPropertyNames(file)
+local sheetName = sheets[0]  -- 0-indexed!
+
+-- 3. Get rows
+local items = file[sheetName]
+local nItems = getCollectionLength(items)
+
+-- 4. Process rows
+for i = 0, nItems - 1 do
+    local row = items[i]
+    local x = row["X"]       -- column access by header name
+    local y = row["Y"]
+    local z = row["Z"]       -- nil if column doesn't exist
+
+    if type(x) == "number" and type(y) == "number" then
+        -- process valid row
+    else
+        writeln(string.format("Skipping row %d: invalid data", i + 1))
+    end
+end
+```
+
+### XML Reading
+
+```lua
+local xml = getContentsFromFile(FileType.Xml, "Select XML file", "*.xml")
+local props = getExpandoObjectPropertyNames(xml)
+local nProps = getCollectionLength(props)
+
+for i = 0, nProps - 1 do
+    local value = xml[props[i]]
+    writeln(props[i] .. " = " .. tostring(value))
+end
+```
+
+### Text File Reading
+
+```lua
+local file = getContentsFromFile(FileType.Text, "", filename)
+local lines = {}
+for s in file:gmatch("[^\r\n]+") do
+    table.insert(lines, s)
+end
+```
+
+### JSON
+
+```lua
+-- Read JSON
+local data = deserializeJson(jsonString)
+
+-- Export to JSON
+exportToJson(luaTable, "output.json")
+```
+
+### File Output
+
+```lua
+exportStringToFile(contentString, "output.txt")
+```
+
+### Directory Listing
+
+```lua
+local files = getFilesInFolder(folderPath)
+local folders = getFoldersInFolder(folderPath)
+```
+
+## Running Commands
+
+### Pattern
+
+Commands require a **trailing space** to execute:
+
+```lua
+runCommand("_COMMANDNAME args ")  -- note trailing space
+```
+
+### Return Value
+
+```lua
+local result = runCommand("_RC-ShowVersion  ")
+local logOutput = result.log       -- command output text
+local status = result.result       -- execution status
+```
+
+### Common AutoCAD Commands
+
+```lua
+-- System variables
+runCommand("_PICKADD 0 ")
+runCommand("_FILEDIA 1 ")
+runCommand("_ORTHOMODE 0 ")
+runCommand("_GRID _OFF ")
+runCommand("_SNAP _OFF ")
+runCommand("_NAVVCUBE _OFF ")
+runCommand("_DYNMODE 3 ")
+runCommand("_SELECTIONCYCLING 2 ")
+
+-- Units setup
+runCommand('_-UNITS 2 3 1 3 0 _NO ')
+
+-- Object snap modes
+runCommand("_-OSNAP _END,_MID,_CEN,_NOD,_INT,_PER,_TAN,_NEA ")
+
+-- Color
+runCommand("_-COLOR _BYLAYER ")
+
+-- Drawing
+runCommand("_CIRCLE " .. x .. "," .. y .. " " .. radius .. " ")
+
+-- Zoom
+runCommand("_z _e ")       -- zoom extents
+runCommand("_zoom _e\n")   -- alternate form
+
+-- Regen / Purge
+runCommand("_REGEN ")
+runCommand("_-PURGE _ALL * _NO ")
+
+-- Save
+runCommand("_QSAVE ")
+```
+
+### LISP Wrapping
+
+For commands that need LISP syntax:
+
+```lua
+runCommand('(command "._ZOOM" "_EXTENTS") ')
+```
+
+### RC Commands
+
+```lua
+runCommand("RC-CommandName ")  -- see 050-commands.html for full list
+```
+
+### Version Checking
+
+```lua
+local tmp = runCommand("_RC-ShowVersion  ").log
+local rcVersion = tmp:match("version (%d+%.%d+)%.%d+%.%d+")
+```
+
+## Advanced Patterns
+
+### Undo Buffer
+
+Wrap modifications in an undo group so they can be undone as one step:
+
+```lua
+beginUndoBufferItem()
+
+-- create/modify objects here
+local obj = insertPointObject(alignment, rctype, variant, position)
+obj.name = "="
+obj.name = "New Name"
+
+endUndoBufferItem()
+```
+
+### Selection Sets
+
+After creating objects, make them the current selection:
+
+```lua
+local created = {}
+for i = 0, nItems - 1 do
+    local obj = insertPointObject(alignment, rctype, variant, positions[i])
+    table.insert(created, obj)
+end
+setSelectionSet(created)
+```
+
+### External Libraries
+
+Call C# methods from external DLLs:
+
+```lua
+-- Open a shapefile via DotSpatial
+local shapefile = runExternalLibraryFunction(
+    "DotSpatial.Data.Shapefile",
+    "OpenFile",
+    {shapefilePath}
+)
+
+-- Create a .NET object
+local milepost = createExternalLibraryObject(
+    "RailCOMPLETE.Model.GeometryModels.Milepost",
+    {},  -- constructor args
+    {Name = "1.0KM", Pos = 1000, Mileage = 1000}  -- property assignments
+)
+```
+
+### Library Inclusion
+
+```lua
+lib1 = includeLuaFile("Lua\\Functions\\lib1.lua")
+lib2 = includeLuaFile("Lua\\Functions\\lib2.lua")
+
+-- Use library functions
+lib2.zoomExtents()
+local id = RC__identify(obj)
+```
+
+### CAD Entity Creation
+
+Create raw AutoCAD entities:
+
+```lua
+-- Points and vectors
+local point = cadInterface.createCadEntity("Geometry.Point3d", {x, y, z})
+local vector = cadInterface.createCadEntity("Geometry.Vector3d", {0, 0, 1})
+local point2d = cadInterface.createCadEntity("Geometry.Point2d", {x, y})
+
+-- Circle
+local circle = cadInterface.createCadEntity("DatabaseServices.Circle", {point, vector, radius})
+
+-- Line
+local line = cadInterface.createCadEntity("DatabaseServices.Line", {
+    getAcadPoint3D(p1), getAcadPoint3D(p2)
+})
+
+-- Polyline
+local polyline = cadInterface.createCadEntity("DatabaseServices.Polyline", {})
+local index = 0
+for _, v in pairs(points) do
+    polyline:AddVertexAt(index, cadInterface.createCadEntity("Geometry.Point2d", {v.X, v.Y}), 0, 0, 0)
+    index = index + 1
+end
+polyline.Closed = true
+
+-- MText
+local text = cadInterface.createCadEntity("DatabaseServices.MText", {})
+text.Height = 2.0
+text.TextHeight = 1.25
+text.TextStyleId = cadInterface.getTextStyleId("ISO")
+text.Contents = "Line 1\\PLine 2"  -- \\P = newline
+text.Attachment = cadInterface.createCadEntity("DatabaseServices.AttachmentPoint", {"TopRight"})
+text.Location = getAcadPoint3D(textPosition)
+
+-- Dimension
+local dim = cadInterface.createCadEntity("DatabaseServices.AlignedDimension", {})
+dim.XLine1Point = getAcadPoint3D(p1)
+dim.XLine2Point = getAcadPoint3D(p2)
+dim.DimLinePoint = getAcadPoint3D(dimPoint)
+dim.DimensionText = string.format("%.0f", distance)
+
+-- Add entities to drawing
+cadInterface.addEntitiesToModelSpace({circle, line, polyline, text})
+```
+
+### Block Operations
+
+```lua
+-- Create a block
+local blockName = "myBlock_" .. generateGuid()
+cadInterface.createBlock(blockName, entities)
+
+-- Create block reference (instance)
+local ref = cadInterface.createBlockReference(blockName, insertionPoint)
+ref.ScaleFactors = cadInterface.createCadEntity("Geometry.Scale3d", {scaleFactor})
+
+-- Check if block exists
+if not cadInterface.blockExist(blockName) then
+    cadInterface.createBlock(blockName, entities)
+end
+
+-- Get CAD entity from RC object
+local cadEntity = cadInterface.getCadEntityFromRcObject(rcObject)
+```
+
+### Table Operations
+
+These extend Lua's built-in table library:
+
+```lua
+-- Transform collection to Lua table
+local luaTable = table.select(rcCollection, function(x) return x end)
+
+-- Filter
+local filtered = table.where(items, function(x) return x.RcType == rctype_Signal end)
+
+-- Get first match
+local first = table.firstOrNil(items, function(x) return x.code == "V1" end)
+
+-- Sort
+table.sort(items, function(a, b) return a.Mileage < b.Mileage end)
+```
+
+### Coordinate Conversions
+
+```lua
+-- Get alignment-relative coordinates
+local linearAddr = getLinearAddress(worldPosition, alignment)
+-- linearAddr.DistanceAlong, .LateralOffset, .LongitudinalOffset, .VerticalOffset
+
+-- Get alignment info at a point
+local ai = alignment:getAlignmentInfo(point)
+if ai.NormalProjectionExists then
+    local pos = ai.RelativePosition
+    local mileage = ai.Mileage
+end
+
+-- WCS vector from ACS vector
+local wcsVector = getWcsVectorFromAcsVector(obj, lateralOffset, longitudinalOffset)
+```
+
+## Real Examples
+
+### Import Objects from Excel
+
+```lua
+--[[
+    Insert objects at XY coordinates from Excel
+    ============================================
+    2025-01-15 v1.0 AUTHOR Created
+--]]
+
+function writeln(t) write((t or "") .. "\n") end
+function show(t) writeln(t) askForKeyword(t, {"OK"}) end
+
+show([[
+    Insert objects at XY(Z) coordinates from Excel
+    ===============================================
+    Input: Excel file with columns X, Y (and optionally Z).
+    Usage: Select file, select template object, objects are inserted.
+]])
+
+-- Select file
+local filename = askForFileName("Select Excel file with X, Y columns")
+local file = getContentsFromFile(FileType.Excel, "", filename)
+local sheets = getExpandoObjectPropertyNames(file)
+local sheetName = sheets[0]
+local items = file[sheetName]
+local nItems = getCollectionLength(items)
+
+show(nItems .. " rows found in sheet '" .. sheetName .. "'")
+
+-- Select template object
+show("Select an existing object as template. Its RcType and Variant will be used.")
+local template = askForObject("Select template object")
+if template.Alignment == nil then
+    show("Aborting: template object must have an alignment.")
+    return
+end
+
+-- Process rows
+local objTable = {}
+local nCreated = 0
+
+beginUndoBufferItem()
+
+for i = 0, nItems - 1 do
+    local row = items[i]
+    local x = row["X"]
+    local y = row["Y"]
+    local z = row["Z"]
+
+    if type(x) ~= "number" or type(y) ~= "number" then
+        writeln(string.format("Skipping row %d: X='%s' or Y='%s' is not a number.",
+            i + 1, tostring(x), tostring(y)))
+        goto continue
+    end
+
+    local p = getPoint3D(x, y)
+    local obj = insertPointObject(
+        template.Alignment, template.RcType, template.Variant, p
+    )
+
+    if obj then
+        if z and type(z) == "number" then
+            obj.VerticalOffset = "="
+            obj.VerticalOffset = z
+        end
+        table.insert(objTable, obj)
+        nCreated = nCreated + 1
+        writeln(string.format("%d: Created at (%.3f, %.3f)", i + 1, x, y))
+    else
+        writeln(string.format("Row %d: Failed to create object at (%.3f, %.3f)", i + 1, x, y))
+    end
+
+    ::continue::
+end
+
+endUndoBufferItem()
+
+setSelectionSet(objTable)
+show("\n" .. nCreated .. " objects created out of " .. nItems .. " rows.")
+```
+
+### Batch Create Tracks from Shapefile
+
+```lua
+--[[
+    Import tracks from Shapefile
+    ============================
+    2025-02-01 v1.0 AUTHOR Created
+--]]
+
+lib1 = includeLuaFile("Lua\\Functions\\lib1.lua")
+lib2 = includeLuaFile("Lua\\Functions\\lib2.lua")
+
+local _HEADER_ = "Import Tracks"
+local _TRACK_VARIANT_ = "Traverses et rails - 3D simple"
+
+show("Import tracks from a Shapefile (.shp)")
+
+local shapefilePath = askForFileName("Select the Shapefile (.shp)")
+local shapefile = runExternalLibraryFunction(
+    "DotSpatial.Data.Shapefile", "OpenFile", {shapefilePath}
+)
+local shapes = table.select(shapefile.ShapeIndices)
+local geometries = table.select(shapefile.Features, function(x) return x.Geometry end)
+
+writeln("Importing from: " .. shapefilePath)
+
+beginUndoBufferItem()
+
+for _, shape in pairs(shapes) do
+    local recordNumber = shape.RecordNumber
+    local trackName = tostring(shapefile.Attributes.Table.Rows[recordNumber - 1].ItemArray[2])
+
+    -- Skip very short segments (derailers)
+    if shape.NumParts == 1 and shape.NumPoints == 2 and
+       math.abs(geometries[recordNumber].Length - 2.0) < 0.1 then
+        writeln("Skipping derailer: " .. trackName, _warning)
+        goto continue
+    end
+
+    local parts = table.select(shape.Parts)
+    for _, part in pairs(parts) do
+        local coords = table.select(part)
+        local points = {}
+
+        for idx, vertex in ipairs(coords) do
+            local z = shapefile.Z[shape.StartIndex + idx - 1]
+            table.insert(points, getPoint3D(vertex.X, vertex.Y, z))
+        end
+
+        local alignment = createAlignmentObject(rctype_Track, _TRACK_VARIANT_, points)
+        if alignment then
+            alignment.code = "="
+            alignment.code = trackName
+            alignment.name = alignment.name  -- force save
+            writeln("Created track: " .. trackName)
+        else
+            writeln("Failed to create track: " .. trackName, _error)
+        end
+    end
+
+    ::continue::
+end
+
+endUndoBufferItem()
+runCommand("_z _e ")
+show("Import complete")
+```
+
+### Draw AutoCAD Circles from Coordinates
+
+```lua
+--[[
+    Insert circles at XY coordinates
+    =================================
+    2025-01-10 v1.0 AUTHOR Created
+--]]
+
+function writeln(t) write((t or "") .. "\n") end
+function show(t) writeln(t) askForKeyword(t, {"OK"}) end
+
+local filename = askForFileName("Select Excel file with X, Y columns")
+local file = getContentsFromFile(FileType.Excel, "", filename)
+local sheets = getExpandoObjectPropertyNames(file)
+local items = file[sheets[0]]
+local nItems = getCollectionLength(items)
+local radius = 0.5
+
+-- Check RC version for undo buffer support
+local tmp = runCommand("_RC-ShowVersion  ").log
+local rcVersion = tmp:match("version (%d+%.%d+)%.%d+%.%d+")
+
+for i = 0, nItems - 1 do
+    local x = items[i]["X"]
+    local y = items[i]["Y"]
+
+    if type(x) == "number" and type(y) == "number" then
+        if rcVersion > "2024.2" then
+            beginUndoBufferItem()
+            local insertionPoint = cadInterface.createCadEntity("Geometry.Point3d", {x, y, 0})
+            local normalVector = cadInterface.createCadEntity("Geometry.Vector3d", {0, 0, 1})
+            local circle = cadInterface.createCadEntity("DatabaseServices.Circle",
+                {insertionPoint, normalVector, radius})
+            cadInterface.addEntitiesToModelSpace({circle})
+            endUndoBufferItem()
+        else
+            runCommand("_CIRCLE " .. x .. "," .. y .. " " .. radius .. " ")
+        end
+        writeln(string.format("%04d Inserted circle at (%.3f, %.3f)", i + 1, x, y))
+    end
+end
+
+show("Done. " .. nItems .. " rows processed.")
+```
+
+## Common Pitfalls
+
+### 0-Indexed RC Collections vs 1-Indexed Lua Tables
+
+RailCOMPLETE collections (from `getRelatedObjects()`, `getContentsFromFile()`, `filter()`, `getExpandoObjectPropertyNames()`) are **0-indexed**. Lua tables created with `table.insert()` are **1-indexed**.
+
+```lua
+-- RC collection: 0-indexed
+local items = file[sheetName]
+for i = 0, getCollectionLength(items) - 1 do
+    local row = items[i]
+end
+
+-- Lua table: 1-indexed
+local luaTable = {}
+table.insert(luaTable, "a")  -- luaTable[1] = "a"
+```
+
+### askForPoint() Cancel Exception
+
+`askForPoint()` throws an exception when the user presses Escape. Always check for nil:
+
+```lua
+local point = askForPoint("Click a point:")
+if not point then return end
+```
+
+### Trailing Space in runCommand()
+
+Commands won't execute without a trailing space:
+
+```lua
+runCommand("_CIRCLE 0,0 10 ")  -- works (trailing space)
+runCommand("_CIRCLE 0,0 10")   -- may hang waiting for input!
+```
+
+### Formula Reset Before Assignment
+
+To replace a formula-bound property with a concrete value, first reset it with `"="`:
+
+```lua
+obj.VerticalOffset = "="    -- remove formula
+obj.VerticalOffset = 5.0    -- assign value
+```
+
+### goto continue / ::continue:: Pattern
+
+Lua has no `continue` keyword. Use `goto` with a label at the end of the loop body:
+
+```lua
+for i = 0, n - 1 do
+    if shouldSkip then
+        goto continue
+    end
+
+    -- process item
+
+    ::continue::
+end
+```
+
+### string.format() Patterns
+
+```lua
+string.format("%.3f", value)     -- 3 decimal places: "1.234"
+string.format("%04d", number)    -- 4-digit zero-padded: "0042"
+string.format("%d: %s", i, msg)  -- integer and string
+```
+
+### Force Save After Property Changes
+
+After modifying alignment properties, force a save by re-assigning name:
+
+```lua
+alignment.code = "="
+alignment.code = "V1"
+alignment.name = alignment.name  -- triggers save and derived field update
+```
+
+## FileType Constants
+
+```lua
+FileType.Excel    -- .xlsx files
+FileType.Xml      -- .xml files
+FileType.Text     -- .txt files
+FileType.Csv      -- .csv files
+FileType.Json     -- .json files
+FileType.Lua      -- .lua files
+```
+
+## Output Symbols
+
+```lua
+_noSymbol    -- standard output
+_ok          -- green checkmark
+_warning     -- yellow triangle
+_error       -- red X
+```
+
+## Documentation Reference
+
+- **Full API reference**: `.claude/documentation/080-luacommands.html` — all object-level + script-only functions
+- **Lua language tutorial**: `.claude/documentation/070-lua.html` — syntax, types, control structures
+- **RC commands**: `.claude/documentation/050-commands.html` — commands available via `runCommand()`
+- **Debugger**: `.claude/documentation/080-luadebugger.html` — breakpoints, watches, stepping


### PR DESCRIPTION
## Summary
- Add two Claude Code skills: **lua-properties** (guide for Lua-controlled property formulas in DNA XML) and **lua-scripting** (guide for standalone Lua scripts for automation)
- Add HTML reference pages for commands and Lua APIs
- Add conventional commits guideline to CLAUDE.md

## Test plan
- [x] Verify skills are recognized by Claude Code (`/lua-properties`, `/lua-scripting`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)