### PR TITLE
Jbteh mas suspension mast ocs mast height()

### DIFF
--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17056,7 +17056,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="OcsMastHeight" IsModelCheck="false">
-      <Formula>_JBTEH_MAS_suspension_mast_height()</Formula>
+      <Formula>_JBTEH_MAS_suspension_mast_OcsMastHeight()</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <TextPositionLuaExpression Name="SPENNLENGDE" IsModelCheck="false">
@@ -17307,10 +17307,10 @@ return s</Data>
 			end
 		</Formula>
     </LuaFunction>
-    <LuaFunction Name="_JBTEH_MAS_suspension_mast_height()" Description="Computes the drop-arm height (OcsMastHeight) [mm] for this OCS suspension mast based on its vertical offset relative to its cantilever mast's vertical offset and lower console offset (lco)." ReturnType="integer" HideFromUser="false">
-      <Signature>Double _JBTEH_MAS_suspension_mast_height()</Signature>
+    <LuaFunction Name="_JBTEH_MAS_suspension_mast_OcsMastHeight()" Description="Computes the drop-arm height (OcsMastHeight) [mm] for this OCS suspension mast based on its vertical offset relative to its cantilever mast's vertical offset and lower console offset (lco)." ReturnType="integer" HideFromUser="false">
+      <Signature>Double _JBTEH_MAS_suspension_mast_OcsMastHeight()</Signature>
       <Formula>
-		function _JBTEH_MAS_suspension_mast_height()
+		function _JBTEH_MAS_suspension_mast_OcsMastHeight()
 			local relPortal = Relations["Er hengemast festet i åk"][0]
 			local relCantilever = Relations["Er kl-mast for utligger"][0]
 			if getCollectionLength(Relations["Er kl-mast for utligger"]) == 2 and
@@ -17319,7 +17319,8 @@ return s</Data>
 			end
 			local cantileverLco = _JBTEH_UTL_StandardValues(relCantilever.Variant)["lco"]
 			local h = (VerticalOffset - relCantilever.VerticalOffset - cantileverLco + 0.15) * 1000
-			return h
+			local hRounded = math.ceil(h/ 100 + 0.5) * 100
+			return hRounded
 		end
 	  </Formula>	
     </LuaFunction>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17303,25 +17303,27 @@ return s</Data>
       <Signature>String _JBTEH_MAS_yoke_suspension_mast_Model3DName()</Signature>
       <Formula>
 			function _JBTEH_MAS_yoke_suspension_mast_Model3DName()
-				return "NO-BN-3D-EH-MAS-HENGEMAST-I-ÅK-HUP-"..OcsMastProfile:match("%d+x%d+").."-"..OcsMastHeight
+				return "NO-BN-3D-EH-MAS-HENGEMAST-I-ÅK-HUP-"..OcsMastProfile:match("%d+x%d+").."-"..math.floor(OcsMastHeight/ 100 + 0.5) * 100
 			end
 		</Formula>
     </LuaFunction>
     <LuaFunction Name="_JBTEH_MAS_suspension_mast_height()" Description="Computes the drop-arm height (OcsMastHeight) [mm] for this OCS suspension mast based on its vertical offset relative to its cantilever mast's vertical offset and lower console offset (lco)." ReturnType="integer" HideFromUser="false">
       <Signature>Double _JBTEH_MAS_suspension_mast_height()</Signature>
       <Formula>
-			function _JBTEH_MAS_suspension_mast_height()
-				local yokeRel = "Er hengemast festet i åk"
-				local yokes, nYokes = RC__getCollectionOfRelatedObjects(yokeRel)
-				if nYokes == 0 then
-					return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..yokeRel.."' to its OCS yoke.")
-				end
-				local cantileverRel = "Er kl-mast for utligger"
-				local cantilevers, nCantilevers = RC__getCollectionOfRelatedObjects(cantileverRel)
-				if nCantilevers == 0 then
-					return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..cantileverRel.."' to a cantilever mast.")
-				end
-				local cantilever = cantilevers[0]
+		function _JBTEH_MAS_suspension_mast_height()
+			local yokeRel = "Er hengemast festet i åk"
+			local yokes, nYokes = RC__getCollectionOfRelatedObjects(yokeRel)
+			if nYokes == 0 then
+				return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..yokeRel.."' to its OCS yoke.")
+			end
+			local cantileverRel = "Er kl-mast for utligger"
+			local cantilevers, nCantilevers = RC__getCollectionOfRelatedObjects(cantileverRel)
+			local cantilever = cantilevers[0]
+			if nCantilevers == 0 then
+				return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..cantileverRel.."' to a cantilever mast.")
+			end
+		end
+	  </Formula>	
     </LuaFunction>
     <DockPointDefinitions Annotative="true">
       <SnapPoints>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17311,16 +17311,25 @@ return s</Data>
       <Signature>Double _JBTEH_MAS_suspension_mast_OcsMastHeight()</Signature>
       <Formula>
 		function _JBTEH_MAS_suspension_mast_OcsMastHeight()
-			local relPortal = Relations["Er hengemast festet i åk"][0]
-			local relCantilever = Relations["Er kl-mast for utligger"][0]
-			if getCollectionLength(Relations["Er kl-mast for utligger"]) == 2 and
-			   Relations["Er kl-mast for utligger"][1].VerticalOffset &lt; relCantilever.VerticalOffset then
-				relCantilever = Relations["Er kl-mast for utligger"][1]
+			obj = obj or this
+			por, nPor = obj:getRelatedObjects("Er hengemast festet i åk")
+			cnt, nCnt = obj:getRelatedObjects("Er kl-mast for utligger")
+			if nPor == 0 then
+				return obj:getPropertyValue("OcsMastHeight"), _info("ERROR - Relate OCS droparm to its portal.", _error)
+			else
+				if nCnt == 0 then
+					return obj:getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate OCS droparm to at least one cantilever.", _unfinished)
+				elseif nCnt == 1 then
+					local cntLco = _JBTEH_UTL_StandardValues(cnt[0].Variant)["lco"]
+					cntOverheadClearance = cnt[0].VerticalOffset + cntLco
+				else
+					local cntLco0 = _JBTEH_UTL_StandardValues(cnt[0].Variant)["lco"]
+					local cntLco1 = _JBTEH_UTL_StandardValues(cnt[1].Variant)["lco"]
+					cntOverheadClearance = math.min(cnt[0].VerticalOffset + cntLco0, cnt[1].VerticalOffset + cntLco1)
+				end
 			end
-			local cantileverLco = _JBTEH_UTL_StandardValues(relCantilever.Variant)["lco"]
-			local h = (VerticalOffset - relCantilever.VerticalOffset - cantileverLco + 0.15) * 1000
-			local hRounded = math.ceil(h/ 100 + 0.5) * 100
-			return hRounded
+			local h = (VerticalOffset - cntOverheadClearance + 0.15) * 1000
+			return math.ceil(h/100 + 0.5) * 100
 		end
 	  </Formula>	
     </LuaFunction>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17055,6 +17055,10 @@ return s</Data>
       <Formula>_JBTEH_MAS_yoke_suspension_mast_Model3DName()</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
+    <LuaExpression Name="OcsMastHeight" IsModelCheck="false">
+      <Formula>_JBTEH_MAS_suspension_mast_height()</Formula>
+      <Symbol>_noSymbol</Symbol>
+    </LuaExpression>
     <TextPositionLuaExpression Name="SPENNLENGDE" IsModelCheck="false">
       <Formula>_JBTEH_MAS_SpanLengthTextOffset(SpanLengthTextOffsetLateral, SpanLengthTextOffsetAlong)</Formula>
       <Symbol>_noSymbol</Symbol>
@@ -17302,6 +17306,22 @@ return s</Data>
 				return "NO-BN-3D-EH-MAS-HENGEMAST-I-ÅK-HUP-"..OcsMastProfile:match("%d+x%d+").."-"..OcsMastHeight
 			end
 		</Formula>
+    </LuaFunction>
+    <LuaFunction Name="_JBTEH_MAS_suspension_mast_height()" Description="Computes the drop-arm height (OcsMastHeight) [mm] for this OCS suspension mast based on its vertical offset relative to its cantilever mast's vertical offset and lower console offset (lco)." ReturnType="integer" HideFromUser="false">
+      <Signature>Double _JBTEH_MAS_suspension_mast_height()</Signature>
+      <Formula>
+			function _JBTEH_MAS_suspension_mast_height()
+				local yokeRel = "Er hengemast festet i åk"
+				local yokes, nYokes = RC__getCollectionOfRelatedObjects(yokeRel)
+				if nYokes == 0 then
+					return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..yokeRel.."' to its OCS yoke.")
+				end
+				local cantileverRel = "Er kl-mast for utligger"
+				local cantilevers, nCantilevers = RC__getCollectionOfRelatedObjects(cantileverRel)
+				if nCantilevers == 0 then
+					return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..cantileverRel.."' to a cantilever mast.")
+				end
+				local cantilever = cantilevers[0]
     </LuaFunction>
     <DockPointDefinitions Annotative="true">
       <SnapPoints>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17324,13 +17324,14 @@ return s</Data>
 			end
 		</Formula>
     </LuaFunction>
-    <LuaFunction Name="_JBTEH_MAS_suspension_mast_OcsMastHeight()" Description="Computes the drop-arm height (OcsMastHeight) [mm] for this OCS suspension mast based on its vertical offset relative to its cantilever mast's vertical offset and lower console offset (lco)." ReturnType="integer" HideFromUser="false">
-      <Signature>Double _JBTEH_MAS_suspension_mast_OcsMastHeight()</Signature>
+    <LuaFunction Name="_JBTEH_MAS_suspension_mast_OcsMastHeight()" Description="Computes the drop-arm height (OcsMastHeight) [mm] for this OCS suspension mast based on its vertical offset relative to its cantilever mast's vertical offset and lower console offset (lco)." ReturnType="Double" HideFromUser="false">
+      <Signature>Double _JBTEH_MAS_suspension_mast_OcsMastHeight([RailwayPlacedObject obj])</Signature>
       <Formula>
-		function _JBTEH_MAS_suspension_mast_OcsMastHeight()
+		function _JBTEH_MAS_suspension_mast_OcsMastHeight(obj)
 			obj = obj or this
-			por, nPor = obj:getRelatedObjects("Er hengemast festet i åk")
-			cnt, nCnt = obj:getRelatedObjects("Er kl-mast for utligger")
+			local por, nPor = obj:getRelatedObjects("Er hengemast festet i åk")
+			local cnt, nCnt = obj:getRelatedObjects("Er kl-mast for utligger")
+			local cntOverheadClearance
 			if nPor == 0 then
 				return obj:getPropertyValue("OcsMastHeight"), _info("ERROR - Relate OCS droparm to its portal.", _error)
 			else
@@ -17345,10 +17346,10 @@ return s</Data>
 					cntOverheadClearance = math.min(cnt[0].VerticalOffset + cntLco0, cnt[1].VerticalOffset + cntLco1)
 				end
 			end
-			local h = (VerticalOffset - cntOverheadClearance + 0.15) * 1000
-			return math.ceil(h/100 + 0.5) * 100
+			local h = (obj.VerticalOffset - cntOverheadClearance + 0.15) * 1000
+			return math.ceil(h/100) * 100
 		end
-	  </Formula>	
+	  </Formula>
     </LuaFunction>
     <DockPointDefinitions Annotative="true">
       <SnapPoints>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -16316,11 +16316,28 @@ return s</Data>
       <Signature>Double _JBTEH_MAS_OcsMastHeight()</Signature>
       <Formula>
 				function _JBTEH_MAS_OcsMastHeight()
-					r, n = RC__getCollectionOfRelatedObjects("Er åk-mast for åk")
-					if n &gt; 0 then
-						return string.format("%.0f", 500 * ((r[0].RelativeElevation + 1.0) // 0.5)) --[mm]
+					local r, n = getRelatedObjects("Er åk-mast for åk")
+					if n > 0 then
+						local PortalHeight, AdditionalHeight
+						if r[0].Variant:match("12") then
+							PortalHeight = 0.8 --Height of Type 12 portal frames
+						elseif r[0].Variant:match("14") then
+							PortalHeight = 1.2 --Height of Type 14 portal frames
+						elseif r[0].Variant:match("40") then
+							PortalHeight = 0.4  --Height of Type 40 portal frames
+						else
+							PortalHeight = 9.999  --Clearly an error
+						end
+						if r[0].Strengthened then
+							AdditionalHeight = PortalHeight --Portal frame has full height at both ends
+						else
+							AdditionalHeight = 0 --Legacy portals are "flat" at both ends
+						end
+						local MinimumExtraHeight = 0.75
+						return string.format("%.0f", 500 * ((r[0].VerticalOffset + AdditionalHeight + MinimumExtraHeight) // 0.5)) --[mm]
 					else
-						return 8000 --default value, assuming yoke has default RelativeElevation of 7.9
+						--Assume that the 3D library uses steps of 500 mm, assume using tall poles (for AT):
+						return tostring(9500 - 500*math.floor((250 + 1000*VerticalOffset)//500)) --[mm]
 					end
 				end
 			</Formula>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17832,7 +17832,7 @@ return s</Data>
 		  local supportMasts, nSupportMasts = getRelatedObjects("Er åk holdt oppe av kl-mast")
 
 		  if nSupportMasts == 0 then
-			return 0, _unfinished, _info("UNFINISHED - Relate yoke to its support mast(s) using 'Er åk holdt oppe av kl-mast'.")
+			return getPropertyValue("VerticalOffset"), _unfinished, _info("UNFINISHED - Relate yoke to its support mast(s) using 'Er åk holdt oppe av kl-mast'.")
 
 		  elseif nSupportMasts == 1 then
 			local mastBaseElevation = supportMasts[0].geoCoord.Z

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17311,17 +17311,15 @@ return s</Data>
       <Signature>Double _JBTEH_MAS_suspension_mast_height()</Signature>
       <Formula>
 		function _JBTEH_MAS_suspension_mast_height()
-			local yokeRel = "Er hengemast festet i åk"
-			local yokes, nYokes = RC__getCollectionOfRelatedObjects(yokeRel)
-			if nYokes == 0 then
-				return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..yokeRel.."' to its OCS yoke.")
+			local relPortal = Relations["Er hengemast festet i åk"][0]
+			local relCantilever = Relations["Er kl-mast for utligger"][0]
+			if getCollectionLength(Relations["Er kl-mast for utligger"]) == 2 and
+			   Relations["Er kl-mast for utligger"][1].VerticalOffset < relCantilever.VerticalOffset then
+				relCantilever = Relations["Er kl-mast for utligger"][1]
 			end
-			local cantileverRel = "Er kl-mast for utligger"
-			local cantilevers, nCantilevers = RC__getCollectionOfRelatedObjects(cantileverRel)
-			local cantilever = cantilevers[0]
-			if nCantilevers == 0 then
-				return getPropertyValue("OcsMastHeight"), _info("UNFINISHED - Relate with '"..cantileverRel.."' to a cantilever mast.")
-			end
+			local cantileverLco = _JBTEH_UTL_StandardValues(relCantilever.Variant)["lco"]
+			local h = (VerticalOffset - relCantilever.VerticalOffset - cantileverLco + 0.15) * 1000
+			return h
 		end
 	  </Formula>	
     </LuaFunction>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17314,7 +17314,7 @@ return s</Data>
 			local relPortal = Relations["Er hengemast festet i åk"][0]
 			local relCantilever = Relations["Er kl-mast for utligger"][0]
 			if getCollectionLength(Relations["Er kl-mast for utligger"]) == 2 and
-			   Relations["Er kl-mast for utligger"][1].VerticalOffset < relCantilever.VerticalOffset then
+			   Relations["Er kl-mast for utligger"][1].VerticalOffset &lt; relCantilever.VerticalOffset then
 				relCantilever = Relations["Er kl-mast for utligger"][1]
 			end
 			local cantileverLco = _JBTEH_UTL_StandardValues(relCantilever.Variant)["lco"]

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -17590,6 +17590,10 @@ return s</Data>
     <LuaExpression Name="AngularOffset" IsModelCheck="false">
       <Formula>_JBTEH_AAK_AngularOffset()</Formula>
       <Symbol>_noSymbol</Symbol>
+    </LuaExpression>    
+	<LuaExpression Name="VerticalOffset" IsModelCheck="false">
+      <Formula>_JBTEH_AAK_VerticalOffset()</Formula>
+      <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Mileage" IsModelCheck="false">
       <Formula>_JBTEH_AAK_Mileage()</Formula>
@@ -17820,6 +17824,28 @@ return s</Data>
 				end
 			</Formula>
     </LuaFunction>
+	<LuaFunction Name="_JBTEH_AAK_VerticalOffset()" Description="Computes the vertical offset [m] of the yoke bottom above the alignment, based on the highest ground elevation of its support masts plus the minimum clearance height of 7.9 m." ReturnType="Double" HideFromUser="false">
+	  <Signature>Double _JBTEH_AAK_VerticalOffset()</Signature>
+	  <Formula>
+		function _JBTEH_AAK_VerticalOffset()
+		  local supportMasts, nSupportMasts = getRelatedObjects("Er åk holdt oppe av kl-mast")
+
+		  if nSupportMasts == 0 then
+			return 0, _unfinished, _info("UNFINISHED - Relate yoke to its support mast(s) using 'Er åk holdt oppe av kl-mast'.")
+
+		  elseif nSupportMasts == 1 then
+			local mastBaseElevation = supportMasts[0].geoCoord.Z
+			return mastBaseElevation + 7.9
+
+		  else -- nSupportMasts >= 2
+			local mast1BaseElevation = supportMasts[0].geoCoord.Z
+			local mast2BaseElevation = supportMasts[1].geoCoord.Z
+			local highestMastBaseElevation = math.max(mast1BaseElevation, mast2BaseElevation)
+			return highestMastBaseElevation + 7.9
+		  end
+		end
+	  </Formula>
+	</LuaFunction>
     <LuaFunction Name="_JBTEH_AAK_Mileage()" Description="Deduces the galley's / yoke's mileage, based on relation to one or two yoke support masts." ReturnType="Double" HideFromUser="false">
       <Signature>Double _JBTEH_AAK_Mileage()</Signature>
       <Formula>

--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -16319,14 +16319,14 @@ return s</Data>
 					local r, n = getRelatedObjects("Er åk-mast for åk")
 					if n > 0 then
 						local PortalHeight, AdditionalHeight
-						if r[0].Variant:match("12") then
+						if r[0].Variant == "Type 12" then
 							PortalHeight = 0.8 --Height of Type 12 portal frames
-						elseif r[0].Variant:match("14") then
+						elseif r[0].Variant == "Type 14" then
 							PortalHeight = 1.2 --Height of Type 14 portal frames
-						elseif r[0].Variant:match("40") then
+						elseif r[0].Variant == "Type 40" then
 							PortalHeight = 0.4  --Height of Type 40 portal frames
 						else
-							PortalHeight = 9.999  --Clearly an error
+							return tostring(getPropertyValue("OcsMastHeight")), _info("ERROR - Yoke Variant ["..r[0].Variant.."] has no known portal frame height.", _error)
 						end
 						if r[0].Strengthened then
 							AdditionalHeight = PortalHeight --Portal frame has full height at both ends

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ pool:
 variables:
 - group: Code-signing-variables
 
-name: $(dnaAdmName)-$(dnaBuildNumberMajor).$(dnaBuildNumberMinor).12
+name: $(dnaAdmName)-2021.a.13
 
 steps:
 


### PR DESCRIPTION
### JBTEH_MAS_suspension_mast_OcsMastHeight():
Added function _JBTEH_MAS_suspension_mast_OcsMastHeight() which decides the suspension masts height based on cantilever height. If two cantilevers are attached to the suspension mast, the lowest hanging cantilever decides height of suspension mast.

### Changes to _JBTEH_MAS_yoke_suspension_mast_Model3DName():
Changed function to give integer when calling OcsMastHeight. If the rounding is omitted OcsMastheight returns float, which is does not match with the name of 3D geometries (e.g. 4600.0 instead of 4600) 

### Bruk av Claud:

Nesten alt av Lua har blitt skrevet av Claud. Jeg ga en prompt som inkluderte:
* Navn på fil som skulle endres
* Skills filer som fungerer som guides for Claud, skrevet av SVNOE
* Pseudokode for problemet
* Jeg ba den også se gjennom alle LuaExpressions for objektet, og bruke samme navne- og kodekonvensjoner.

Etter dette måtte jeg inn og fikse på noen veldig små syntaxfeil. Dette kunne nok ha blitt unngått med bedre prompting. Alt i alt så er det stort potensiale.