### PR TITLE
Chore: Configure allowed permissions for claude code

### DIFF
--- a/.claude/hooks/block_cd_chaining.sh
+++ b/.claude/hooks/block_cd_chaining.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# PreToolUse hook: block cd-chaining (cd foo && ...) and git -C usage
+# so that fine-grained Bash permission rules are not bypassed.
+
+input=$(cat)
+command=$(echo "$input" | sed -n 's/.*"command":"\([^"]*\)".*/\1/p')
+
+# Strip single- and double-quoted strings to avoid false positives in message text
+unquoted=$(echo "$command" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g")
+
+if echo "$unquoted" | grep -qE '\bcd\s+\S+\s*(&&|;|\|)'; then
+  echo "BLOCKED: Do not chain cd with other commands. Use absolute paths or separate bash calls." >&2
+  exit 2
+fi
+
+if echo "$unquoted" | grep -qE '\bgit\s+-C\b'; then
+  echo "BLOCKED: Do not use git -C. Use a separate cd call first, then run git commands normally." >&2
+  exit 2
+fi

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,13 +1,27 @@
 {
   "permissions": {
     "allow": [
+      "Task",
+      "Glob",
+      "Grep",
+      "LS",
+      "Read",
+      "Edit",
+      "MultiEdit",
+      "Write",
+      "WebFetch",
+      "WebSearch",
+      "Bash(cd:*)",
+      "Bash(tail *)",
       "Bash(dir:*)",
       "Bash(findstr:*)",
       "Bash(grep:*)",
       "Bash(find:*)",
       "Bash(where:*)",
       "Bash(awk:*)",
-      "Bash(powershell -Command \"gh pr view 10566 --json state,isDraft,author,title,body,reviews\")",
+      "Bash(ls:*)",
+      "Bash(sort:*)",
+      "Bash(wc:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr checks:*)",
@@ -18,9 +32,20 @@
       "Bash(git log:*)",
       "Bash(git show:*)",
       "Bash(git rev-parse:*)",
-      "Bash(sort:*)",
-      "Bash(ls:*)",
-      "Bash(wc:*)"
+      "Bash(git remote:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block_cd_chaining.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Configured Claude Code permissions.

Allow:
- Navigating
- Reading
- Writing
- Fetching web content
- Git read actions

Ask:
- Git write actions

Also added a hook to auto deny chained cd commands because they trigger a permission prompt every time. Claude will learn to avoid them.