### PR TITLE
fix: Changed Hovedsignal to MainSignal and Dvergsignal to DwarfSignal…

### DIFF
--- a/NO-BN/Lua/LuaTooltipPages/TooltipViews/NO-BN-Distance-RcType-Dir.xaml
+++ b/NO-BN/Lua/LuaTooltipPages/TooltipViews/NO-BN-Distance-RcType-Dir.xaml
@@ -51,8 +51,8 @@ while true do
 	end
 	if downObj.dir == objDir then 
 		if RCType =="JBTSA_SIG Signal" then 
-			if Hovedsignal:match("Hs[2-3]") and downObj.Hovedsignal:match("Hs[2-3]") then break 
-			elseif (Hovedsignal =="-" and Dvergsignal =="Ja") and (downObj.Hovedsignal =="-" and downObj.Dvergsignal =="Ja") then break 
+			if MainSignal:match("Hs[2-3]") and downObj.MainSignal:match("Hs[2-3]") then break 
+			elseif (MainSignal =="-" and DwarfSignal =="Ja") and (downObj.MainSignal =="-" and downObj.DwarfSignal =="Ja") then break 
 			end
 		else
 			break
@@ -72,8 +72,8 @@ while true do
 	end
 	if upObj.dir == objDir then 
 		if RCType =="JBTSA_SIG Signal" then 
-			if Hovedsignal:match("Hs[2-3]") and upObj.Hovedsignal:match("Hs[2-3]") then break 
-			elseif (Hovedsignal =="-" and Dvergsignal =="Ja") and (upObj.Hovedsignal =="-" and upObj.Dvergsignal =="Ja") then break 
+			if MainSignal:match("Hs[2-3]") and upObj.MainSignal:match("Hs[2-3]") then break 
+			elseif (MainSignal =="-" and DwarfSignal =="Ja") and (upObj.MainSignal =="-" and upObj.DwarfSignal =="Ja") then break 
 			end
 		else
 			break


### PR DESCRIPTION
## Summary

Updated Hovedsignal → MainSignal and Dvergsignal → DwarfSignal in the Distance (type, dir) custom tooltip Lua code to match the renamed properties in the DNA

## Background

The signal properties Hovedsignal and Dvergsignal were renamed to MainSignal and DwarfSignal in the DNA, but the custom tooltip NO-BN-Distance-RcType-Dir.xaml was not updated accordingly. This caused a Lua nil error when selecting a hovedsignal with the Distance (type, dir) tooltip active:

`Lua exception error: [string "input"]: 16: attempt to index a nil value (global 'hovedsignal')`


## Showcase

<img width="868" height="565" alt="bilde" src="https://github.com/user-attachments/assets/c7c9ba05-b180-42d9-9fca-3395e97cfc52" />

## Realted issues

closes #290
