### PR TITLE
Portal brackets

### DIFF
--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB200.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB200.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8353428d10f2ba9e43789aa73b33f5d8cbce9b1d4fa7dc3118a42a2905fdf7a7
+size 226229

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB220.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB220.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5afb15bc1d9c7ff8da55bed397d990b18338da729135da363c4a0b5504beaf7c
+size 262673

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB240.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB240.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea2579ab23a5c2aa3a1592d6ac17f1e77a36c98656385a7c92636654bc7e759f
+size 262673

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba7014af173642060db48cf000fdd489c0c4df3297f728dc322d071d2a8c770a
+size 227634

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB280.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEB280.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbdc4361642c0beeb1430d3ab9e1743c823e5844d8a6c77f3ae7859c416dd2d5
+size 230265

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEM260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-01-HEM260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d518e1c1b6a3c354ee9b4244ce7fdd701e9d31469fc03c87f84091dfc2706354
+size 262673

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB200.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB200.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a076e825536e287078c5fd9bce57965b5f03924119ad3a05d3baf0d371f4bf54
+size 239206

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB220.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB220.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86d3737876aa43e061939da7ce1f33b69b82a1a5ac91205ba7d39932db330244
+size 245795

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB240.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB240.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8126ac5ced3a5405153af6ce4bfd4da5387b00cf275d4491688333515f09c6fe
+size 238365

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab0fab6900bd7243d6282d9cdd2aedef7624ae594b3c60479a74d556ced7042c
+size 249927

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB280.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEB280.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f9fd6d8f48de350a5c7f93773ee2b89294c84232e0816099f19c1b0aea90714
+size 245028

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEM260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-2-KONSOLL-02-HEM260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59a1b144cd9f02d878b7960839b76dafe5a2c770a69401c4a7582c628b4eecae
+size 237744

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB200.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB200.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d40e4a22a3ca97aa3d66fcae8ce26414cdb515dba1f2237113a2520a6bed3fd
+size 172256

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB220.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB220.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ce5bc99b98cd0097c979f20ff665516d91725101c1a228be2e5c65495ef80c6
+size 172680

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB240.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB240.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aefb861fe7a13f0188cd830f66ce1a44a6599f2c6a5ae431ad715c68ef409af4
+size 172354

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a45f9b4f6c8138473736a0283a6064e09d72f643267b084a04dde6516ac04452
+size 191968

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB280.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEB280.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99daef2c7a141c8d0ac6dad97bb24305c2c4e40f016386262d1dc9aa3775d3af
+size 194045

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEM260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-01-HEM260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3208cec60280ee499bbaa43b12f719c63adf31eb6c1b38bdc29d839ddeb64b43
+size 171948

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB200.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB200.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d32b8ee663bb2cb97374739dc8cbd1bf71d53bee635ba83cdac9a31014a46c58
+size 191441

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB220.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB220.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88a4cc6f5a0e9d3e81e034d94d878fbad2765e279b283911bc2f763573252faf
+size 185057

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB240.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB240.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36e104dc47e5527cf7f1d5381b68c8415f376ff8a0c64fb889cee43e1e33159d
+size 192771

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4d823b73e258335e90fb1b2016c27bf1833eb05d7d2009b237a81b6fe938022
+size 193706

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB280.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEB280.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50c5d51d7eed5e3911981a69fe6e81e41a1a49ef8e384e15447061ac3c44e54a
+size 195434

--- a/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEM260.dwg
+++ b/NO-BN/3D/STD-2026.1/EH/NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-2-KONSOLL-02-HEM260.dwg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:384ecde26979d073355172d0ae7c9226a8697dd0324a0952c28989da8e9861cc
+size 194903

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1877,53 +1877,28 @@
 
 		<!-- Brackets ("konsoller") attached to each supporting mast of the OCS portal. -->
 
-		<LuaExpression Name="Geometry3D_1.Name">
-			<Formula>
-				local r, n = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
-				return _JBTEH_AAK_KONSOLL_Geometry3DName(r[0], n)
-			</Formula>
-		</LuaExpression>
+		<LuaExpression Name="Geometry3D_1.Name"><Formula>_JBTEH_AAK_KONSOLL_Geometry3DName(0)</Formula></LuaExpression>
 		<LuaExpression Name="Geometry3D_1.Parent"><Formula>0</Formula></LuaExpression>
-		<LuaExpression Name="Geometry3D_1.Offset.Y">
-			<Formula>
-				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
-				return _JBTEH_AAK_KONSOLL_Placement(r[0])
-			</Formula>
-		</LuaExpression>
-		<LuaExpression Name="Geometry3D_1.Rotation.Z">
-			<Formula>
-				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
-				return _JBTEH_AAK_KONSOLL_Rotation(r[0])
-			</Formula>
-		</LuaExpression>
+		<LuaExpression Name="Geometry3D_1.Offset.Y"><Formula>_JBTEH_AAK_KONSOLL_Placement(0)</Formula></LuaExpression>
+		<LuaExpression Name="Geometry3D_1.Rotation.Z"><Formula>_JBTEH_AAK_KONSOLL_Rotation(0)</Formula></LuaExpression>
 		<LuaExpression Name="Geometry3D_1.RotationBeforeOffset"><Formula>true</Formula></LuaExpression>
 
-		<LuaExpression Name="Geometry3D_2.Name">
-			<Formula>
-				local r, n = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
-				return _JBTEH_AAK_KONSOLL_Geometry3DName(r[1], n)
-			</Formula>
-		</LuaExpression>
+		<LuaExpression Name="Geometry3D_2.Name"><Formula>_JBTEH_AAK_KONSOLL_Geometry3DName(1)</Formula></LuaExpression>
 		<LuaExpression Name="Geometry3D_2.Parent"><Formula>0</Formula></LuaExpression>
-		<LuaExpression Name="Geometry3D_2.Offset.Y">
-			<Formula>
-				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
-				return _JBTEH_AAK_KONSOLL_Placement(r[1])
-			</Formula>
-		</LuaExpression>
-		<LuaExpression Name="Geometry3D_2.Rotation.Z">
-			<Formula>
-				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
-				return _JBTEH_AAK_KONSOLL_Rotation(r[1])
-			</Formula>
-		</LuaExpression>
+		<LuaExpression Name="Geometry3D_2.Offset.Y"><Formula>_JBTEH_AAK_KONSOLL_Placement(1)</Formula></LuaExpression>
+		<LuaExpression Name="Geometry3D_2.Rotation.Z"><Formula>_JBTEH_AAK_KONSOLL_Rotation(1)</Formula></LuaExpression>
 		<LuaExpression Name="Geometry3D_2.RotationBeforeOffset"><Formula>true</Formula></LuaExpression>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Placement()" ReturnType="Double"
-			Description="Bracket offset along the portal beam toward the related mast [m] (signed, negative).">
-			<Signature>Double _JBTEH_AAK_KONSOLL_Placement(Reference mast)</Signature>
+			Description="Bracket offset along the portal beam toward the related mast [m] (signed, negative). idx selects which supporting mast (0 = first, 1 = second).">
+			<Signature>Double _JBTEH_AAK_KONSOLL_Placement(Int idx)</Signature>
 			<Formula>
-				function _JBTEH_AAK_KONSOLL_Placement(mast)
+				function _JBTEH_AAK_KONSOLL_Placement(idx)
+					local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+					local mast = r[idx]
+					if mast == nil then
+						return 0
+					end
 					local dx = geoCoord.X - mast.geoCoord.X
 					local dy = geoCoord.Y - mast.geoCoord.Y
 					return -math.sqrt(dx * dx + dy * dy)
@@ -1932,12 +1907,17 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_DistanceToEdge()" ReturnType="Double"
-			Description="Distance from the åk's nearest beam end to the mast's outer edge [m]. Equals (mast half cross-section width) + (distance from the beam end to the mast centerline). The åk beam length is taken from _JBTEH_AAK_Length(); the cross-section number (e.g. HEB220) is the section depth in mm.">
-			<Signature>Double _JBTEH_AAK_KONSOLL_DistanceToEdge(Reference mast)</Signature>
+			Description="Distance from the åk's nearest beam end to the mast's outer edge [m]. Equals (mast half cross-section width) + (distance from the beam end to the mast centerline). The åk beam length is taken from _JBTEH_AAK_Length(); the cross-section number (e.g. HEB220) is the section depth in mm. idx selects which supporting mast (0 or 1).">
+			<Signature>Double _JBTEH_AAK_KONSOLL_DistanceToEdge(Int idx)</Signature>
 			<Formula>
-				function _JBTEH_AAK_KONSOLL_DistanceToEdge(mast)
+				function _JBTEH_AAK_KONSOLL_DistanceToEdge(idx)
+					local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+					local mast = r[idx]
+					if mast == nil then
+						return math.huge
+					end
 					local L = tonumber(_JBTEH_AAK_Length():match("%d+"))
-					local d = math.abs(_JBTEH_AAK_KONSOLL_Placement(mast))
+					local d = math.abs(_JBTEH_AAK_KONSOLL_Placement(idx))
 					local halfWidth = tonumber(mast.OcsPoleCrossSection:match("%d+")) * 0.0005
 					return math.min(d, math.abs(L - d)) + halfWidth
 				end
@@ -1945,14 +1925,16 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Geometry3DName()" ReturnType="String"
-			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the mast's outer edge sits within 250 mm of the nearest portal beam end.">
-			<Signature>String _JBTEH_AAK_KONSOLL_Geometry3DName(Reference mast, Int n)</Signature>
+			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the mast's outer edge sits within 250 mm of the nearest portal beam end. idx selects which supporting mast (0 or 1).">
+			<Signature>String _JBTEH_AAK_KONSOLL_Geometry3DName(Int idx)</Signature>
 			<Formula>
-				function _JBTEH_AAK_KONSOLL_Geometry3DName(mast, n)
+				function _JBTEH_AAK_KONSOLL_Geometry3DName(idx)
+					local r, n = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+					local mast = r[idx]
 					if mast == nil or n == 0 then
 						return nil
 					end
-					local subVariant = (_JBTEH_AAK_KONSOLL_DistanceToEdge(mast) > 0.250) and "01" or "02"
+					local subVariant = (_JBTEH_AAK_KONSOLL_DistanceToEdge(idx) > 0.250) and "01" or "02"
 					local strengthened = Strengthened and "2" or "1"
 					if Variant == "Type 12" then
 						return string.upper(string.format("NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-%s-KONSOLL-%s-%s", strengthened, subVariant, mast.OcsPoleCrossSection))
@@ -1966,11 +1948,11 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Rotation()" ReturnType="Double"
-			Description="Bracket Z-rotation [deg]. Returns 180 when the mast's outer edge sits within 250 mm of the nearest portal beam end so the alt sub-variant 02 mounts the correct way around.">
-			<Signature>Double _JBTEH_AAK_KONSOLL_Rotation(Reference mast)</Signature>
+			Description="Bracket Z-rotation [deg]. Returns 180 when the mast's outer edge sits within 250 mm of the nearest portal beam end so the alt sub-variant 02 mounts the correct way around. idx selects which supporting mast (0 or 1).">
+			<Signature>Double _JBTEH_AAK_KONSOLL_Rotation(Int idx)</Signature>
 			<Formula>
-				function _JBTEH_AAK_KONSOLL_Rotation(mast)
-					if _JBTEH_AAK_KONSOLL_DistanceToEdge(mast) > 0.250 then
+				function _JBTEH_AAK_KONSOLL_Rotation(idx)
+					if _JBTEH_AAK_KONSOLL_DistanceToEdge(idx) > 0.250 then
 						return 0
 					else
 						return 180

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1886,8 +1886,6 @@
 		<LuaExpression Name="Geometry3D_2.Name"><Formula>_JBTEH_AAK_KONSOLL_Geometry3DName(1)</Formula></LuaExpression>
 		<LuaExpression Name="Geometry3D_2.Parent"><Formula>0</Formula></LuaExpression>
 		<LuaExpression Name="Geometry3D_2.Offset.Y"><Formula>_JBTEH_AAK_KONSOLL_Placement(1)</Formula></LuaExpression>
-		<LuaExpression Name="Geometry3D_2.Rotation.Z"><Formula>_JBTEH_AAK_KONSOLL_Rotation(1)</Formula></LuaExpression>
-		<LuaExpression Name="Geometry3D_2.RotationBeforeOffset"><Formula>true</Formula></LuaExpression>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Placement()" ReturnType="Double"
 			Description="Bracket offset along the portal beam toward the related mast [m]. idx selects which of the portal's two supporting masts the bracket belongs to.">
@@ -1919,7 +1917,7 @@
 					local L = tonumber(_JBTEH_AAK_Length():match("%d+"))
 					local d = math.abs(_JBTEH_AAK_KONSOLL_Placement(idx))
 					local halfWidth = tonumber(mast.OcsPoleCrossSection:match("%d+")) * 0.0005
-					return math.min(d, math.abs(L - d)) + halfWidth
+					return math.min(d, math.abs(L - d)) - halfWidth
 				end
 			</Formula>
 		</LuaFunction>

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1932,19 +1932,20 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_DistanceToEdge()" ReturnType="Double"
-			Description="Distance from the mast's centerline to the nearest end of the portal beam [m]. The åk's local Y axis runs along the beam from its insertion point; the beam length is taken from _JBTEH_AAK_Length().">
+			Description="Distance from the åk's nearest beam end to the mast's outer edge [m]. Equals (mast half cross-section width) + (distance from the beam end to the mast centerline). The åk beam length is taken from _JBTEH_AAK_Length(); the cross-section number (e.g. HEB220) is the section depth in mm.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_DistanceToEdge(Reference mast)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_DistanceToEdge(mast)
 					local L = tonumber(_JBTEH_AAK_Length():match("%d+"))
 					local d = math.abs(_JBTEH_AAK_KONSOLL_Placement(mast))
-					return math.min(d, math.abs(L - d))
+					local halfWidth = tonumber(mast.OcsPoleCrossSection:match("%d+")) * 0.0005
+					return math.min(d, math.abs(L - d)) + halfWidth
 				end
 			</Formula>
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Geometry3DName()" ReturnType="String"
-			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the mast's centerline sits within 250 mm of the nearest portal beam end.">
+			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the mast's outer edge sits within 250 mm of the nearest portal beam end.">
 			<Signature>String _JBTEH_AAK_KONSOLL_Geometry3DName(Reference mast, Int n)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Geometry3DName(mast, n)
@@ -1965,7 +1966,7 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Rotation()" ReturnType="Double"
-			Description="Bracket Z-rotation [deg]. Returns 180 when the mast's centerline sits within 250 mm of the nearest portal beam end so the alt sub-variant 02 mounts the correct way around.">
+			Description="Bracket Z-rotation [deg]. Returns 180 when the mast's outer edge sits within 250 mm of the nearest portal beam end so the alt sub-variant 02 mounts the correct way around.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_Rotation(Reference mast)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Rotation(mast)

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1888,7 +1888,7 @@
 		<LuaExpression Name="Geometry3D_2.Offset.Y"><Formula>_JBTEH_AAK_KONSOLL_Placement(1)</Formula></LuaExpression>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Placement()" ReturnType="Double"
-			Description="Bracket offset along the portal beam toward the related mast [m]. idx selects which of the portal's two supporting masts the bracket belongs to.">
+			Description="Bracket offset along the portal toward the related mast [m]. idx selects which of the portal's two supporting masts the bracket belongs to.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_Placement(Int idx)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Placement(idx)
@@ -1905,7 +1905,7 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_DistanceToEdge()" ReturnType="Double"
-			Description="Distance from the portal's nearest beam end to the outer edge of the supporting mast [m]. idx selects which of the portal's two supporting masts the bracket belongs to.">
+			Description="Distance from the portal's nearest end to the outer edge of the supporting mast [m]. idx selects which of the portal's two supporting masts the bracket belongs to.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_DistanceToEdge(Int idx)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_DistanceToEdge(idx)
@@ -1923,7 +1923,7 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Geometry3DName()" ReturnType="String"
-			Description="Returns the bracket's 3D object model name. Uses an alternative sub-variant when the supporting mast sits close to the portal's nearest beam end. idx selects which of the portal's two supporting masts the bracket belongs to.">
+			Description="Returns the bracket's 3D object model name. Uses an alternative sub-variant when the supporting mast sits close to the portal's nearest end. idx selects which of the portal's two supporting masts the bracket belongs to.">
 			<Signature>String _JBTEH_AAK_KONSOLL_Geometry3DName(Int idx)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Geometry3DName(idx)

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1890,7 +1890,7 @@
 		<LuaExpression Name="Geometry3D_2.RotationBeforeOffset"><Formula>true</Formula></LuaExpression>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Placement()" ReturnType="Double"
-			Description="Bracket offset along the portal beam toward the related mast [m] (signed, negative). idx selects which supporting mast (0 = first, 1 = second).">
+			Description="Bracket offset along the portal beam toward the related mast [m]. idx selects which of the portal's two supporting masts the bracket belongs to.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_Placement(Int idx)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Placement(idx)
@@ -1907,7 +1907,7 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_DistanceToEdge()" ReturnType="Double"
-			Description="Distance from the åk's nearest beam end to the mast's outer edge [m]. Equals (mast half cross-section width) + (distance from the beam end to the mast centerline). The åk beam length is taken from _JBTEH_AAK_Length(); the cross-section number (e.g. HEB220) is the section depth in mm. idx selects which supporting mast (0 or 1).">
+			Description="Distance from the portal's nearest beam end to the outer edge of the supporting mast [m]. idx selects which of the portal's two supporting masts the bracket belongs to.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_DistanceToEdge(Int idx)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_DistanceToEdge(idx)
@@ -1925,7 +1925,7 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Geometry3DName()" ReturnType="String"
-			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the mast's outer edge sits within 250 mm of the nearest portal beam end. idx selects which supporting mast (0 or 1).">
+			Description="Returns the bracket's 3D object model name. Uses an alternative sub-variant when the supporting mast sits close to the portal's nearest beam end. idx selects which of the portal's two supporting masts the bracket belongs to.">
 			<Signature>String _JBTEH_AAK_KONSOLL_Geometry3DName(Int idx)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Geometry3DName(idx)
@@ -1948,7 +1948,7 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Rotation()" ReturnType="Double"
-			Description="Bracket Z-rotation [deg]. Returns 180 when the mast's outer edge sits within 250 mm of the nearest portal beam end so the alt sub-variant 02 mounts the correct way around. idx selects which supporting mast (0 or 1).">
+			Description="Returns the angular offset needed to mount the bracket the correct way around when the alternative sub-variant is used. idx selects which of the portal's two supporting masts the bracket belongs to.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_Rotation(Int idx)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Rotation(idx)

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1932,18 +1932,19 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_DistanceToEdge()" ReturnType="Double"
-			Description="Gap between bracket insertion point and the mast's near edge [m]. Cross-section number (e.g. HEB220) is the section depth in mm; half-width = depth/2.">
+			Description="Distance from the mast's centerline to the nearest end of the portal beam [m]. The åk's local Y axis runs along the beam from its insertion point; the beam length is taken from _JBTEH_AAK_Length().">
 			<Signature>Double _JBTEH_AAK_KONSOLL_DistanceToEdge(Reference mast)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_DistanceToEdge(mast)
-					local halfWidth = tonumber(mast.OcsPoleCrossSection:match("%d+")) * 0.0005
-					return math.abs(_JBTEH_AAK_KONSOLL_Placement(mast)) - halfWidth
+					local L = tonumber(_JBTEH_AAK_Length():match("%d+"))
+					local d = math.abs(_JBTEH_AAK_KONSOLL_Placement(mast))
+					return math.min(d, math.abs(L - d))
 				end
 			</Formula>
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Geometry3DName()" ReturnType="String"
-			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the bracket sits within 250 mm of the mast edge.">
+			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the mast's centerline sits within 250 mm of the nearest portal beam end.">
 			<Signature>String _JBTEH_AAK_KONSOLL_Geometry3DName(Reference mast, Int n)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Geometry3DName(mast, n)
@@ -1964,7 +1965,7 @@
 		</LuaFunction>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Rotation()" ReturnType="Double"
-			Description="Bracket Z-rotation (degrees). Returns 180 when the bracket sits within 250 mm of the mast edge so the alt sub-variant 02 mounts the correct way around.">
+			Description="Bracket Z-rotation [deg]. Returns 180 when the mast's centerline sits within 250 mm of the nearest portal beam end so the alt sub-variant 02 mounts the correct way around.">
 			<Signature>Double _JBTEH_AAK_KONSOLL_Rotation(Reference mast)</Signature>
 			<Formula>
 				function _JBTEH_AAK_KONSOLL_Rotation(mast)

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1911,6 +1911,12 @@
 				return _JBTEH_AAK_KONSOLL_Placement(r[1])
 			</Formula>
 		</LuaExpression>
+		<LuaExpression Name="Geometry3D_2.Rotation.Z">
+			<Formula>
+				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+				return _JBTEH_AAK_KONSOLL_Rotation(r[1])
+			</Formula>
+		</LuaExpression>
 		<LuaExpression Name="Geometry3D_2.RotationBeforeOffset"><Formula>true</Formula></LuaExpression>
 
 		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Placement()" ReturnType="Double"

--- a/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsPoles.xml
@@ -1482,7 +1482,9 @@
 		</Variants>
 		
 		<DynamicProperty Type="Representation3D" Subtype="Geometry3D"/>
-		
+		<DynamicProperty Type="Representation3D" Subtype="Geometry3D"/>
+		<DynamicProperty Type="Representation3D" Subtype="Geometry3D"/>
+
 		<CustomProperty DataType="Enumeration" Name="Length" DisplayName="Lengde" DefaultValue="11m"
 			Description="The overhead catenary system (OCS) portal length (oyl), given in predefined lengths in 1 meter steps. Each may be composed of subparts, where the joints may hinder drop arm mounting.">
 			<Values Variant="Type 12">
@@ -1858,11 +1860,11 @@
 			<Signature>String _JBTEH_AAK_Geometry3DName()</Signature>
 			<Formula>
 				function _JBTEH_AAK_Geometry3DName()
-					if Variant == "Type 12" then 
+					if Variant == "Type 12" then
 						return string.upper(string.format("NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-%d-%02d-%s", Strengthened and "2" or "1", Length:sub(1,-2)-10, Length))
-					elseif Variant == "Type 14" then 
+					elseif Variant == "Type 14" then
 						return string.upper(string.format("NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-%d-%02d-%s", Strengthened and "2" or "1", Length:sub(1,-2)-27, Length))
-					elseif Variant == "Type 40" then 
+					elseif Variant == "Type 40" then
 						return string.upper(string.format("NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-40-%02d-%s", Length:sub(1,-2)-9, Length))
 					elseif Variant == "OCS gantry" then
 						return "NO-BN-3D-EH-AAK-UTLIGGERÅK-6M"
@@ -1872,7 +1874,103 @@
 				end
 			</Formula>
 		</LuaFunction>
-		
+
+		<!-- Brackets ("konsoller") attached to each supporting mast of the OCS portal. -->
+
+		<LuaExpression Name="Geometry3D_1.Name">
+			<Formula>
+				local r, n = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+				return _JBTEH_AAK_KONSOLL_Geometry3DName(r[0], n)
+			</Formula>
+		</LuaExpression>
+		<LuaExpression Name="Geometry3D_1.Parent"><Formula>0</Formula></LuaExpression>
+		<LuaExpression Name="Geometry3D_1.Offset.Y">
+			<Formula>
+				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+				return _JBTEH_AAK_KONSOLL_Placement(r[0])
+			</Formula>
+		</LuaExpression>
+		<LuaExpression Name="Geometry3D_1.Rotation.Z">
+			<Formula>
+				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+				return _JBTEH_AAK_KONSOLL_Rotation(r[0])
+			</Formula>
+		</LuaExpression>
+		<LuaExpression Name="Geometry3D_1.RotationBeforeOffset"><Formula>true</Formula></LuaExpression>
+
+		<LuaExpression Name="Geometry3D_2.Name">
+			<Formula>
+				local r, n = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+				return _JBTEH_AAK_KONSOLL_Geometry3DName(r[1], n)
+			</Formula>
+		</LuaExpression>
+		<LuaExpression Name="Geometry3D_2.Parent"><Formula>0</Formula></LuaExpression>
+		<LuaExpression Name="Geometry3D_2.Offset.Y">
+			<Formula>
+				local r = getRelatedObjects(rel_OcsPortal_IsSupportedBy_OcsPole)
+				return _JBTEH_AAK_KONSOLL_Placement(r[1])
+			</Formula>
+		</LuaExpression>
+		<LuaExpression Name="Geometry3D_2.RotationBeforeOffset"><Formula>true</Formula></LuaExpression>
+
+		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Placement()" ReturnType="Double"
+			Description="Bracket offset along the portal beam toward the related mast [m] (signed, negative).">
+			<Signature>Double _JBTEH_AAK_KONSOLL_Placement(Reference mast)</Signature>
+			<Formula>
+				function _JBTEH_AAK_KONSOLL_Placement(mast)
+					local dx = geoCoord.X - mast.geoCoord.X
+					local dy = geoCoord.Y - mast.geoCoord.Y
+					return -math.sqrt(dx * dx + dy * dy)
+				end
+			</Formula>
+		</LuaFunction>
+
+		<LuaFunction Name="_JBTEH_AAK_KONSOLL_DistanceToEdge()" ReturnType="Double"
+			Description="Gap between bracket insertion point and the mast's near edge [m]. Cross-section number (e.g. HEB220) is the section depth in mm; half-width = depth/2.">
+			<Signature>Double _JBTEH_AAK_KONSOLL_DistanceToEdge(Reference mast)</Signature>
+			<Formula>
+				function _JBTEH_AAK_KONSOLL_DistanceToEdge(mast)
+					local halfWidth = tonumber(mast.OcsPoleCrossSection:match("%d+")) * 0.0005
+					return math.abs(_JBTEH_AAK_KONSOLL_Placement(mast)) - halfWidth
+				end
+			</Formula>
+		</LuaFunction>
+
+		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Geometry3DName()" ReturnType="String"
+			Description="Returns the bracket's 3D model name. Sub-variant 02 is used when the bracket sits within 250 mm of the mast edge.">
+			<Signature>String _JBTEH_AAK_KONSOLL_Geometry3DName(Reference mast, Int n)</Signature>
+			<Formula>
+				function _JBTEH_AAK_KONSOLL_Geometry3DName(mast, n)
+					if mast == nil or n == 0 then
+						return nil
+					end
+					local subVariant = (_JBTEH_AAK_KONSOLL_DistanceToEdge(mast) > 0.250) and "01" or "02"
+					local strengthened = Strengthened and "2" or "1"
+					if Variant == "Type 12" then
+						return string.upper(string.format("NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-12-%s-KONSOLL-%s-%s", strengthened, subVariant, mast.OcsPoleCrossSection))
+					elseif Variant == "Type 14" then
+						return string.upper(string.format("NO-BN-3D-EH-AAK-KONTAKTLEDNINGSÅK-TYPE-14-%s-KONSOLL-%s-%s", strengthened, subVariant, mast.OcsPoleCrossSection))
+					else
+						return nil
+					end
+				end
+			</Formula>
+		</LuaFunction>
+
+		<LuaFunction Name="_JBTEH_AAK_KONSOLL_Rotation()" ReturnType="Double"
+			Description="Bracket Z-rotation (degrees). Returns 180 when the bracket sits within 250 mm of the mast edge so the alt sub-variant 02 mounts the correct way around.">
+			<Signature>Double _JBTEH_AAK_KONSOLL_Rotation(Reference mast)</Signature>
+			<Formula>
+				function _JBTEH_AAK_KONSOLL_Rotation(mast)
+					if _JBTEH_AAK_KONSOLL_DistanceToEdge(mast) > 0.250 then
+						return 0
+					else
+						return 180
+					end
+				end
+			</Formula>
+		</LuaFunction>
+
 		<InsertPointObject Name="Type 12" DisplayBlockName="NO-BN-2D-JBTEH_AAK-KONTAKTLEDNINGSÅK-11000-{% if SymbolMode == 'Schematic' %}Schematic{% else %}Metric{% endif %}"
 				DefaultSnapMode="Point" SnapToAlignment="true" SnapDistance="4">
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>


### PR DESCRIPTION
## Sammendrag

Legger til konsoller (brackets) i 3D-modellen for KL-åk type 12 og type 14. Hver åk får to konsoller, én ved hver støttemast, i tillegg til den eksisterende åk-geometrien (`Geometry3D_0`).

- **3D-modeller:** 24 nye DWG-filer under `NO-BN/3D/STD-2026.1/EH/` som dekker type 12 og 14, undervariant 01 og 02, og mast-tverrsnittene HEB200/220/240/260/280 og HEM260 (commit `131262e0`).
- **Lua-formeler:** `Geometry3D_1` og `Geometry3D_2` på `JBTEH_AAK Kontaktledningsåk` bindes til fire nye hjelpefunksjoner (`_JBTEH_AAK_KONSOLL_Placement`, `_DistanceToEdge`, `_Geometry3DName`, `_Rotation`) i `NO-BN-OcsPoles.xml`.
- **Undervariant-logikk:** Undervariant `02` og 180° Z-rotasjon brukes når avstanden fra åkens nærmeste bjelkeende til mastens ytterkant er under 250 mm — dvs. når mastens ytterkant ligger så nær bjelkeenden at standardkonsollen ikke får tilstrekkelig utheng.

## Skjermbilder

#### Åk type 14 med HEB mast:

<img width="311" height="545" alt="bilde" src="https://github.com/user-attachments/assets/688650db-80d7-40e2-872c-29dfdd6f0974" />

#### Åk type 14 med HEM mast:

<img width="311" height="545" alt="bilde" src="https://github.com/user-attachments/assets/5146afcf-386b-44d9-aa84-104f34533516" />

#### Åk type 12 med HEB mast:

<img width="311" height="545" alt="bilde" src="https://github.com/user-attachments/assets/6a8b244e-7343-4861-95ec-55865fb9b21b" />

#### Åk type 12 med HEM mast:

<img width="311" height="545" alt="bilde" src="https://github.com/user-attachments/assets/2ab2a4d5-104b-43ae-8c97-0ed87ccd8d9d" />

