### PR TITLE
Match standard properties with 2026.1 dna

### DIFF
--- a/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
+++ b/NO-BN/DNA/NO-BN-2021.a-DNA-patch_13.xml
@@ -453,34 +453,41 @@
   <PropertyOverride Name="TimeStamp" Category="Basic" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="additionalName" Category="Basic" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="lang" Category="Basic" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="Variant" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="Variant" DisplayName="Variant" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="ProxySymbolBlockName" DisplayName="Proxy blokknavn for 2D-symbolet" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="ProxySymbolAttDefText" DisplayName="Proxy tekst i 2D-symbolet" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Seq" DisplayName="Sekvensnummer" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="code" DisplayName="Kode" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="name" DisplayName="Objektnavn" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Discipline" DisplayName="Fag" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Stage" DisplayName="Fasekode XXxx-YYyy" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="Tag" DisplayName="Banedata objekt-ID" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="description" DisplayName="Beskrivelse" Category="General" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="Alignment" DisplayName="Egen linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="Mileage" DisplayName="Profil egen linje (PEL)" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="Alignment" DisplayName="Linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="TargetAlignment" DisplayName="Avvikende / tilstøtende linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="ReferenceAlignment" DisplayName="Referanselinje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="ReferenceMileage" DisplayName="Km" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="SideOfAlignment" DisplayName="Side av egen linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="SideOfAlignment" DisplayName="Side av egen linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="true" />
   <PropertyOverride Name="dir" DisplayName="Retning" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="pos" DisplayName="Plassering fra start i egen linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="DistanceToAlignment" DisplayName="Sideavsett fra egen linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="RelativeElevation" DisplayName="Høyde over egen linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="TargetAlignment" DisplayName="Tilstøtende linje" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="DistanceAlong" DisplayName="Avstand fra linjestart [m]" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="Mileage" DisplayName="Profil langs linje [m]" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="ReferenceMileage" DisplayName="Km iht. referanselinje [m]" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="LateralOffset" DisplayName="Sideavsett fra linje [m]" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="LongitudinalOffset" DisplayName="Offset langs line [m]" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="VerticalOffset" DisplayName="Høyde over linje [m]" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="DistanceToAlignment" DisplayName="Avstand til linje [m]" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="AngularOffset" DisplayName="Vinkel-tillegg" Category="Aligned object" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="SymbolMode" DisplayName="Symbolmodus" Category="Presentation" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="DrawTail" DisplayName="Tegne halen" Category="Presentation" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="DrawTailExtension" DisplayName="Forlenge halen" Category="Presentation" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="SymbolFrame" DisplayName="Symbolramme" Category="Presentation" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="KmStigerMotVenstre" Category="Presentation" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Category="Presentation" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Color" DisplayName="Farge" Category="CAD" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Layer" DisplayName="Lag" Category="CAD" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Linetype" DisplayName="Linjetype" Category="CAD" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Lineweight" DisplayName="Linjevekt" Category="CAD" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="GlobalWidth" DisplayName="Global linjebredde" Category="CAD" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="geoCoord" DisplayName="Koordinater" Category="3D" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="geoCoord" DisplayName="Innsettingspunkt i WCS (øst, nord, h.o.h.)" Category="3D" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="Layer3D" DisplayName="3D-geometri lag" Category="3D" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Var0" Category="Local variables" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Var1" Category="Local variables" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Var2" Category="Local variables" SortOrderPriority="2147483647" Suppressed="false" />
@@ -491,14 +498,14 @@
   <PropertyOverride Name="Var7" Category="Local variables" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Var8" Category="Local variables" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="Var9" Category="Local variables" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="LuaExpressions" DisplayName="Lua uttrykk" Category="Formulas" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="LuaExpressions" DisplayName="Lua formler" Category="Formulas" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="model" DisplayName="railML modell" Category="Misc" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="kind" DisplayName="railML avart" Category="Misc" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="derailSide" DisplayName="Avsporingsside" Category="Misc" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="SwitchGeometry" DisplayName="Sporvekselgeometri" Category="Connections" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyOverride Name="ConnectionCourse" DisplayName="Forbindelsesretning" Category="Connections" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="ContinuingWithBegin" DisplayName="Påfølgende spor starter her" Category="Connections" SortOrderPriority="2147483647" Suppressed="false" />
-  <PropertyOverride Name="ExtendingFromEnd" DisplayName="Foregående spor ender her" Category="Connections" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="ContinuingWithBegin" DisplayName="Påfølgende linje starter her" Category="Connections" SortOrderPriority="2147483647" Suppressed="false" />
+  <PropertyOverride Name="ExtendingFromEnd" DisplayName="Foregående linje ender her" Category="Connections" SortOrderPriority="2147483647" Suppressed="false" />
   <PropertyCategory Name="Document" DisplayName="Dokument" Collapsed="false" />
   <PropertyCategory Name="File" DisplayName="Fil" Collapsed="false" />
   <PropertyCategory Name="External Data Files" DisplayName="Eksterne datafiler" Collapsed="false" />
@@ -513,6 +520,7 @@
   <PropertyCategory Name="Presentation" DisplayName="2D presentasjon" Collapsed="true" />
   <PropertyCategory Name="CAD" DisplayName="CAD" Collapsed="true" />
   <PropertyCategory Name="3D" DisplayName="3D geometri" Collapsed="true" />
+  <PropertyCategory Name="2D Projection" DisplayName="2D projeksjon" Collapsed="true" />
   <PropertyCategory Name="Local variables" DisplayName="Lokale variable" Collapsed="true" />
   <PropertyCategory Name="Earthing" DisplayName="Jording" Collapsed="true" />
   <PropertyCategory Name="Watch text" DisplayName="Watch tekst" Collapsed="true" />
@@ -520,7 +528,7 @@
   <PropertyCategory Name="Attachment" DisplayName="Vedheng" Collapsed="true" />
   <PropertyCategory Name="Sections" DisplayName="Seksjoner" Collapsed="true" />
   <PropertyCategory Name="Formulas" DisplayName="Formler" Collapsed="true" />
-  <PropertyCategory Name="Misc" DisplayName="railML og annet" Collapsed="true" />
+  <PropertyCategory Name="Misc" Collapsed="true" />
   <PropertyCategory Name="Interlocking" DisplayName="Forrigling" Collapsed="true" />
   <PropertyCategory Name="Alignment" Collapsed="true" />
   <PropertyCategory Name="Main signal" DisplayName="railML hovedsignal" Collapsed="true" />
@@ -1331,7 +1339,7 @@
         <Value>Skilt</Value>
       </Values>
     </CustomProperty>
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-A-1-0-VLB-018" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
       <BlockNameFormat JoinBy="-">
@@ -1373,7 +1381,7 @@
 				{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="true" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="true" />
       <SymbolAttribute Tag="T01">
         <Value>{{LabelItem1}}</Value>
       </SymbolAttribute>
@@ -1388,32 +1396,32 @@
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject DisplayName="Etikett A" Name="A-1-0-VRB-018" VariantName="A-1-0-VRB-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-A-1-0-VRB-018-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject DisplayName="Etikett B" Name="B-1-0-HLT-018" VariantName="B-1-0-HLT-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-B-1-0-HRB-018-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject DisplayName="Etikett C" Name="C-1-0-HLT-025" VariantName="C-1-0-HLT-025" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-C-1-0-HRB-025-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject DisplayName="Etikett C (2 linjer)" Name="C-1-1-HLT-025-018" VariantName="C-1-1-HLT-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-C-1-0-HRB-025-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject DisplayName="Etikett D" Name="D-1-1-HRB-025-018" VariantName="D-1-1-HRB-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-1-HRB-025-018-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject DisplayName="Etikett D (3 linjer)" Name="D-1-2-HRB-025-018" VariantName="D-1-2-HRB-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
@@ -7207,7 +7215,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -7223,7 +7231,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
       <BlockNameFormat JoinBy="-">NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="W">
         <Value>{{Text}}</Value>
       </SymbolAttribute>
@@ -7232,7 +7240,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Watch" VariantName="Watch" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
@@ -7337,7 +7345,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -7364,102 +7372,102 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Proxy type 1" VariantName="Proxy type 1" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 2" VariantName="Proxy type 2" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type X" VariantName="Proxy type X" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 4" VariantName="Proxy type 4" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 5" VariantName="Proxy type 5" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 6" VariantName="Proxy type 6" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 7" VariantName="Proxy type 7" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 8" VariantName="Proxy type 8" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 9" VariantName="Proxy type 9" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 10" VariantName="Proxy type 10" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 11" VariantName="Proxy type 11" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 12" VariantName="Proxy type 12" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 13" VariantName="Proxy type 13" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 14" VariantName="Proxy type 14" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 15" VariantName="Proxy type 15" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 16" VariantName="Proxy type 16" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 17" VariantName="Proxy type 17" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 18" VariantName="Proxy type 18" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 19" VariantName="Proxy type 19" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
     <InsertPointObject Name="Proxy type 20" VariantName="Proxy type 20" DisplayBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
     </InsertPointObject>
@@ -7533,7 +7541,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -7551,7 +7559,7 @@ return s</Data>
     <CustomProperty DataType="UInt16" Name="KofThemeCode" DisplayName="KOF_sosikode" Description="The 'KofThemeCode' custom attribute [UInt16] should hold a 3- or 4-digit SOSI cartographic object nomenclature code according to Norwegian standard." DefaultValue="7871" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
       <BlockNameFormat JoinBy="-">NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="W">
         <Value>{{Text}}</Value>
       </SymbolAttribute>
@@ -7560,7 +7568,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="KOF Koordinatliste" VariantName="KOF Koordinatliste" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="SymbolFrame" Value="Watch" />
     </InsertPointObject>
     <TextAttribute BindingProperty="name" CadAttributeTag="OBJEKTNAVN" X="0" Y="8" DoNotRotateWithAlignment="false" Layer="JBTFE@OBJEKTNAVN" Color="ByBlock" Justify="MiddleCenter" Height="1.25" Width="0" Rotation="0" Annotative="true" ObliqueAngle="15" Constant="false" Invisible="false" Lock="false" IsMtext="false" />
@@ -7963,7 +7971,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -7979,7 +7987,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="mc_NumberOfOcpAreas" DisplayName="Antall OCP områder" Description="Number of peration / Control Point (OCP) areas to which the object belongs. Most objects shall belong to an OCP, holding properties such as location name and/or resource names." Category="Model check" ReadOnly="true" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="X">
         <Value>{{Variant}}</Value>
       </SymbolAttribute>
@@ -7988,7 +7996,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject DisplayName="Sporbruk" Name="Hovedspor" VariantName="Hovedspor" DisplayBlockName="NO-BN-2D-JBTRC_SEKSJON-INNSETTING-SYMBOL-Schematic" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="SymbolFrame" Value="Symbolramme-R2.75" />
       <SetValue Key="DelimiterType" Value="JBTFE_DIV Sporbrukgrense" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
@@ -8077,7 +8085,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -8094,7 +8102,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_MRK-MARKOER-{{SymbolMode}}" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
       <BlockNameFormat JoinBy="-">NO-BN-2D-JBTFE_MRK-MARKOER-{{SymbolMode}}</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="FARGE">
         <Value>{{code}}</Value>
       </SymbolAttribute>
@@ -8103,7 +8111,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Sporbrukgrense" VariantName="Sporbrukgrense" DisplayBlockName="NO-BN-2D-JBTFE_MRK-MARKOER-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="0.0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="dir" Value="both" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
@@ -8172,7 +8180,7 @@ return s</Data>
 				function _JBTFE_DIV_sporbrukgrense_code()
 					first = DownSections.Count == 0  and "-" or DownSections[0].Code
 					second = UpSections.Count == 0  and "-" or UpSections[0].Code
-					if KmStigerMotVenstre then	first, second = second, first end
+					if MileageIncreasesTowardsLeft then	first, second = second, first end
 					return "(" .. first .. "/" .. second .. ")"
 				end
 			</Formula>
@@ -8183,7 +8191,7 @@ return s</Data>
 				function _JBTFE_DIV_sporbrukgrense_objectInfo()
 					first = DownSections.Count == 0  and "-" or DownSections[0].Variant
 					second = UpSections.Count == 0  and "-" or UpSections[0].Variant
-					if KmStigerMotVenstre then	first, second = second, first end
+					if MileageIncreasesTowardsLeft then	first, second = second, first end
 					return "Sporbruk: " .. first .. "/" .. second
 				end
 			</Formula>
@@ -9155,7 +9163,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -9638,7 +9646,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -9789,7 +9797,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -10181,7 +10189,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -10399,7 +10407,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -10572,7 +10580,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -10729,7 +10737,7 @@ return s</Data>
       <Variant Name="Sporfortsettelse" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -10740,7 +10748,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -10777,7 +10785,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Sporfortsettelse" VariantName="Sporfortsettelse" DisplayBlockName="NO-BN-2D-JBTKO_SPF-FORBINDELSE-FORTSETTELSE-0-0-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <TextAttribute BindingProperty="name" CadAttributeTag="OBJEKTNAVN" X="0" Y="1" DoNotRotateWithAlignment="false" Layer="JBTKO@OBJEKTNAVN" Color="ByBlock" Justify="MiddleCenter" Height="0.5" Width="0" Rotation="0" Annotative="true" ObliqueAngle="15" Constant="false" Invisible="false" Lock="false" IsMtext="false" />
@@ -10893,7 +10901,7 @@ return s</Data>
 							return _error, "Own alignment and continuing alignment cannot be the same ["..first.Code.."]"
 						end
 						--2021-08-23 CLFEY: Leave the text as-is, emphasize showing what is own / what is target:
-						--if KmStigerMotVenstre then
+						--if MileageIncreasesTowardsLeft then
 						--	first, second = second, first 
 						--end
 						return "["..first.Code.."] ==&gt; ["..second.Code.."]"
@@ -10922,7 +10930,7 @@ return s</Data>
       <Variant Name="Sporkryss" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -10933,7 +10941,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -10960,7 +10968,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Sporkryss" VariantName="Sporkryss" DisplayBlockName="NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORKRYSS-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -11081,7 +11089,7 @@ return s</Data>
 						if first.id == second.id then
 							return "Alignment and intersecting alignment cannot be the same ["..first.Code.."]"
 						end
-						if KmStigerMotVenstre then
+						if MileageIncreasesTowardsLeft then
 							first, second = second, first 
 						end
 						return "["..first.Code.."] -X- ["..second.Code.."]"
@@ -11182,7 +11190,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -11193,7 +11201,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -11406,109 +11414,109 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Generell sporveksel" VariantName="Generell sporveksel" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:7 R190 FX 54E3 (KO-800157)" VariantName="1:7 R190 FX 54E3 (KO-800157)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-07-R190-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:9 R190 FX 54E3 (KO-701334)" VariantName="1:9 R190 FX 54E3 (KO-701334)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-09-R190-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:9 R300 FX 54E3 (KO-701287)" VariantName="1:9 R300 FX 54E3 (KO-701287)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-09-R300-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:12 R500 FX 54E3 (KO-701306)" VariantName="1:12 R500 FX 54E3 (KO-701306)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:14 R760 FX 54E3 (KO-701319)" VariantName="1:14 R760 FX 54E3 (KO-701319)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:9 R300 FX 60E1 (KO-701409)" VariantName="1:9 R300 FX 60E1 (KO-701409)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-09-R300-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:11,66 R500 FX 60E1 (KO-800068)" VariantName="1:11,66 R500 FX 60E1 (KO-800068)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-11.66-R500-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:12 R500 FX 60E1 (KO-800068)" VariantName="1:12 R500 FX 60E1 (KO-800068)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:14 R760 FX 60E1 (KO-701372)" VariantName="1:14 R760 FX 60E1 (KO-701372)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:15 R760 FX 60E1 (KO-701382)" VariantName="1:15 R760 FX 60E1 (KO-701382)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-15-R760-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:9 R300 BX 60E1 (KO-800099)" VariantName="1:9 R300 BX 60E1 (KO-800099)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-09-R300-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:8.21 R300 BX 60E1 (KO-065306)" VariantName="1:8.21 R300 BX 60E1 (KO-065306)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-08.21-R300-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:12 R500 BX 60E1 (KO-800090)" VariantName="1:12 R500 BX 60E1 (KO-800090)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:14 R760 BX 60E1 (KO-800108)" VariantName="1:14 R760 BX 60E1 (KO-800108)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:15 R760 BX 60E1 (KO-800164)" VariantName="1:15 R760 BX 60E1 (KO-800164)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-15-R760-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:18.4 R1200 BX 60E1 (KO-800081)" VariantName="1:18.4 R1200 BX 60E1 (KO-800081)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-18.4-R1200-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="1:26.1 R2500 BX 60E1 (KO-701399)" VariantName="1:26.1 R2500 BX 60E1 (KO-701399)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-26.1-R2500-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -11870,7 +11878,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -11881,7 +11889,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -11928,56 +11936,56 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject DisplayName="Sporvekseltunge 1:9 R190" Name="1:9 R190" VariantName="1:9 R190" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-09-R190-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporvekseltunge 1:9 R300" Name="1:9 R300" VariantName="1:9 R300" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-09-R300-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporvekseltunge 1:11,66 R500" Name="1:11,66 R500" VariantName="1:11,66 R500" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-11.66-R500-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporvekseltunge 1:12 R500" Name="1:12 R500" VariantName="1:12 R500" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-12-R500-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporvekseltunge 1:14 R760" Name="1:14 R760" VariantName="1:14 R760" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-14-R760-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporvekseltunge 1:15 R760" Name="1:15 R760" VariantName="1:15 R760" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-15-R760-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporvekseltunge 1:18.4 R1200" Name="1:18.4 R1200" VariantName="1:18.4 R1200" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-18.4-R1200-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporvekseltunge 1:26.1 R2500" Name="1:26.1 R2500" VariantName="1:26.1 R2500" DisplayBlockName="NO-BN-2D-JBTKO_TNG-SPORVEKSELTUNGE-26.1-R2500-V-Metric" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
@@ -12141,7 +12149,7 @@ return s</Data>
         <Value>Skilt</Value>
       </Values>
     </CustomProperty>
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
       <BlockNameFormat JoinBy="-">
@@ -12151,7 +12159,7 @@ return s</Data>
 				{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="true" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="true" />
       <SymbolAttribute Tag="T01">
         <Value>{{LabelItem1}}</Value>
       </SymbolAttribute>
@@ -12166,13 +12174,13 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject DisplayName="Sporveksel SS/Mid (km-retn mot høyre)" Name="D-1-2-HRB-025-018-SPV" VariantName="D-1-2-HRB-025-018-SPV" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Sporveksel SS/Mid (km-retn mot venstre)" Name="D-1-2-HLB-025-018-SPV" VariantName="D-1-2-HLB-025-018-SPV" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HLB-025-018-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="false" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -12203,11 +12211,11 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="LabelItem1" IsModelCheck="false">
-      <Formula>NOBN_trk_getSwitchLabelItem1(KmStigerMotVenstre)</Formula>
+      <Formula>NOBN_trk_getSwitchLabelItem1(MileageIncreasesTowardsLeft)</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="LabelItem2" IsModelCheck="false">
-      <Formula>NOBN_trk_getSwitchLabelItem2(KmStigerMotVenstre)</Formula>
+      <Formula>NOBN_trk_getSwitchLabelItem2(MileageIncreasesTowardsLeft)</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="LabelItem3" IsModelCheck="false">
@@ -12672,7 +12680,7 @@ return s</Data>
       <Variant Name="REB" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -12683,7 +12691,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -12705,7 +12713,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Horisontalt geometripunkt" VariantName="Horisontalt geometripunkt" DisplayBlockName="NO-BN-2D-JBTKO_DIV-KARAKTERISTISK-PUNKT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
       <OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
     </InsertPointObject>
@@ -12835,7 +12843,7 @@ return s</Data>
       <Variant Name="(Linje start/slutt)" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -12846,7 +12854,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -12869,7 +12877,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Vertikalt geometripunkt" VariantName="Vertikalt geometripunkt" DisplayBlockName="NO-BN-2D-JBTKO_DIV-KARAKTERISTISK-PUNKT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
       <OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
     </InsertPointObject>
@@ -13032,7 +13040,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -13043,7 +13051,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -13066,7 +13074,7 @@ return s</Data>
     </SymbolDefinition>
     <InsertPointObject Name="Horisontalgeometrisegment" VariantName="Horisontalgeometrisegment" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
       <SetValue Key="DelimiterType" Value="JBTKO_HOT Horisontalgeometripunkt" />
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
       <OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
     </InsertPointObject>
@@ -13150,7 +13158,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -13161,7 +13169,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -13184,7 +13192,7 @@ return s</Data>
     </SymbolDefinition>
     <InsertPointObject Name="Vertikalprofilsegment" VariantName="Vertikalprofilsegment" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
       <SetValue Key="DelimiterType" Value="JBTKO_VET Vertikalprofilpunkt" />
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
       <OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
     </InsertPointObject>
@@ -13344,7 +13352,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -13466,7 +13474,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -13727,7 +13735,7 @@ return s</Data>
       <Variant Name="Kråkefot" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -13827,7 +13835,7 @@ return s</Data>
       <Variant Name="Skinnejord" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -13939,7 +13947,7 @@ return s</Data>
       <Variant Name="Jordskinne 10x50x530 (17xØ13)" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -14761,7 +14769,7 @@ return s</Data>
       <Variant Name="Bardunfeste fotplate, dobbel" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -14969,7 +14977,7 @@ return s</Data>
       <Variant Name="Streverfeste fotplate og strever for Ø120 hengemast for bru og tunnel" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -15197,7 +15205,7 @@ return s</Data>
       <Variant Name="Veggfeste for KL-avspenning i tunnel" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -15302,7 +15310,7 @@ return s</Data>
       <Variant Name="Konsoll for streverfeste på mast" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -15576,7 +15584,7 @@ return s</Data>
       <Variant Name="Fjæravspenning, dobbel" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -15841,7 +15849,7 @@ return s</Data>
   <LuaExpression Name="Name3D"><Formula>NOBN_com_Name3D()</Formula></LuaExpression>
 	<LuaExpression Name="Layer3D"><Formula>NOBN_com_Layer3D()</Formula></LuaExpression>
 	</ObjectType>
-  <ObjectType DataType="tOrientedElement" Class="RailwayPlacedObject" Name="JBTEH_MAS KL-mast" Layer="JBTEH_MAS" Color="ByLayer" DrawTail="false" DrawTailExtension="false" Group="Kontaktledning/Master" AttMirrorX="{% if KmStigerMotVenstre %}true{% else %}false{% endif %}" AttMirrorY="{% if RightSided %}true{% else %}false{% endif %}">
+  <ObjectType DataType="tOrientedElement" Class="RailwayPlacedObject" Name="JBTEH_MAS KL-mast" Layer="JBTEH_MAS" Color="ByLayer" DrawTail="false" DrawTailExtension="false" Group="Kontaktledning/Master" AttMirrorX="{% if MileageIncreasesTowardsLeft %}true{% else %}false{% endif %}" AttMirrorY="{% if RightSided %}true{% else %}false{% endif %}">
     <Variants DefaultValue="Bjelkemast">
       <Variant Name="Bjelkemast">
         <SetValue Key="OcsMastProfile" Value="HEB240" />
@@ -15879,7 +15887,7 @@ return s</Data>
 			</Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -15890,7 +15898,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -16169,7 +16177,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Bjelkemast" VariantName="Bjelkemast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-BJELKEMAST-{{SymbolMode}}" SubGroup="Ordinære master" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -16181,31 +16189,31 @@ return s</Data>
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="GMB-mast" VariantName="GMB-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GMBMAST-{{SymbolMode}}" SubGroup="Ordinære master" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="H-mast" VariantName="H-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GITTERMAST-H-{{SymbolMode}}" SubGroup="Ordinære master" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="B-mast" VariantName="B-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GITTERMAST-B-{{SymbolMode}}" SubGroup="Ordinære master" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Betongmast" VariantName="Betongmast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-BETONGMAST-{{SymbolMode}}" SubGroup="Ordinære master" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Tremast" VariantName="Tremast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-TREMAST-{{SymbolMode}}" SubGroup="Ordinære master" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -16213,7 +16221,7 @@ return s</Data>
 	
 	<!-- Use Tremast i denne patchen - permanent vil den bli til Rørmast: -->
     <InsertPointObject Name="Rørmast" VariantName="Rørmast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-TREMAST-{{SymbolMode}}" SubGroup="Ordinære master" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -16486,7 +16494,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -16820,7 +16828,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -17371,7 +17379,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -17884,7 +17892,7 @@ return s</Data>
       <Variant Name="H-390" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -17997,7 +18005,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -18604,7 +18612,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -18802,7 +18810,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19046,7 +19054,7 @@ return s</Data>
       <Variant Name="Sugetransformator i kiosk" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19144,7 +19152,7 @@ return s</Data>
       <Variant Name="Autotransformator" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19241,7 +19249,7 @@ return s</Data>
       <Variant Name="Beskyttelsesskjerm 2000x775xØ32 i åk, to felt" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19425,7 +19433,7 @@ return s</Data>
       <Variant Name="Seksjonsisolator" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19545,7 +19553,7 @@ return s</Data>
       <Variant Name="Lineisolator" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19665,7 +19673,7 @@ return s</Data>
       <Variant Name="Stavisolator" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19784,7 +19792,7 @@ return s</Data>
       <Variant Name="Svevende kryss" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19890,7 +19898,7 @@ return s</Data>
       <Variant Name="Strømbro" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -19990,7 +19998,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -20142,7 +20150,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -20292,7 +20300,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -20402,7 +20410,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -20598,7 +20606,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -20764,7 +20772,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -20972,7 +20980,7 @@ return s</Data>
       <Variant Name="Relerom med betjeningsplass, pos 4" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -21089,7 +21097,7 @@ return s</Data>
       <Variant Name="Togdeteksjonsavsnitt for akseltellere" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -21100,7 +21108,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -21117,13 +21125,13 @@ return s</Data>
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="mc_AxleCountersToBeModelchecked" DisplayName="Axle counters to be refreshed" Description="When this section object is refreshed, then the nearest limiting object on each side is refreshed as well." Category="Model check" ReadOnly="true" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="X">
         <Value>{{code}}</Value>
       </SymbolAttribute>
     </SymbolDefinition>
     <InsertPointObject Name="Togdeteksjonsavsnitt for akseltellere" VariantName="Togdeteksjonsavsnitt for akseltellere" DisplayBlockName="NO-BN-2D-JBTRC_SEKSJON-INNSETTING-SYMBOL-Schematic" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="DelimiterType" Value="JBTSA_TEL Akselteller sensor" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
@@ -21223,7 +21231,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -21234,7 +21242,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -21263,7 +21271,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Tellepunkt" VariantName="Tellepunkt" DisplayBlockName="NO-BN-2D-JBTSA_TEL-AKSELTELLER-SENSOR-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="0.75" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="true" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -21390,7 +21398,7 @@ return s</Data>
 							end
 						end
 					end
-					if KmStigerMotVenstre then first, second = second, first end
+					if MileageIncreasesTowardsLeft then first, second = second, first end
 					if first == "-" and second == "-" then
 						return first.."/"..second, _info("UNFINISHED - Create axle counter Section object(s) to obtain the section numbers 'a/b' for the sensor.")
 					else
@@ -21469,7 +21477,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -21627,7 +21635,7 @@ return s</Data>
       <Variant Name="Sporfelt" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -21638,7 +21646,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -21655,7 +21663,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="mc_IsolatedJointsToBeModelchecked" Description="When this section object is refreshed, then the nearest limiting object on each side is refreshed as well." Category="Model check" ReadOnly="true" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="X">
         <Value>{{code}}</Value>
       </SymbolAttribute>
@@ -21664,7 +21672,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Sporfelt" VariantName="Sporfelt" DisplayBlockName="NO-BN-2D-JBTRC_SEKSJON-INNSETTING-SYMBOL-Schematic" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <SetValue Key="SymbolFrame" Value="Symbolramme-R2.75" />
       <SetValue Key="DelimiterType" Value="JBTKO_SKJ Skinneskjøt" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -21754,7 +21762,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -21765,7 +21773,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -21799,7 +21807,7 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Skinneskjøt" VariantName="Skinneskjøt" DisplayBlockName="NO-BN-2D-JBTKO_SKJ-SKINNESKJOET-0-0-0-0-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="0" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="0" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -21940,7 +21948,7 @@ return s</Data>
       <Variant Name="Siemens ELS 710" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -22141,7 +22149,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -22289,7 +22297,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -22484,7 +22492,7 @@ return s</Data>
       <Variant Name="ETCS L2 balisegruppe, dobbel" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -22495,7 +22503,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -22525,13 +22533,13 @@ return s</Data>
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="ETCS L2 balisegruppe, enkel" VariantName="ETCS L2 balisegruppe, enkel" DisplayBlockName="NO-BN-2D-JBTSA_ETC-ETCS-BALISEGRUPPE-ENKEL-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="ETCS L2 balisegruppe, dobbel" VariantName="ETCS L2 balisegruppe, dobbel" DisplayBlockName="NO-BN-2D-JBTSA_ETC-ETCS-BALISEGRUPPE-DOBBEL-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -22612,7 +22620,7 @@ return s</Data>
       <Variant Name="ETCS-balise, styrt" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -22623,7 +22631,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -22658,7 +22666,7 @@ return s</Data>
 				{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="TEKSTOVER">
         <Value>{{TextAbove}}</Value>
       </SymbolAttribute>
@@ -22675,7 +22683,7 @@ return s</Data>
 				{% endif %}
 				Metric
 			</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTRC_INNSETTINGSPUNKT-Schematic" AllowSymbolMove="false" DoNotIncludeInSymbolFrame="true">
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
@@ -22686,13 +22694,13 @@ return s</Data>
       </Attribute>
     </Annotation3DTagDefinition>
     <InsertPointObject Name="ETCS-balise, fast" VariantName="ETCS-balise, fast" DisplayBlockName="NO-BN-2D-JBTSA_ETB-ETCS-BALISE-FAST-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Point">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="ETCS-balise, styrt" VariantName="ETCS-balise, styrt" DisplayBlockName="NO-BN-2D-JBTSA_ETB-ETCS-BALISE-STYRT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Point">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -22836,7 +22844,7 @@ return s</Data>
       <Variant Name="Diversebalisegruppe" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -22847,7 +22855,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -22863,73 +22871,73 @@ return s</Data>
     <CustomProperty DataType="String" Name="mc_NumberOfOcpAreas" DisplayName="Antall OCP områder" Description="Number of peration / Control Point (OCP) areas to which the object belongs. Most objects shall belong to an OCP, holding properties such as location name and/or resource names." Category="Model check" ReadOnly="true" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="BaneNORBaneDataID" DisplayName=" Bane NOR BaneData ID" Description="Formatkrav : ff-ttt-nnnnnn (fagkode, objekttype, 6-sifret tall)." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AllowSymbolMove="true" DoNotIncludeInSymbolFrame="false">
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTRC_INNSETTINGSPUNKT-Schematic" AllowSymbolMove="false" DoNotIncludeInSymbolFrame="true">
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <InsertPointObject Name="Hovedsignalbalisegruppe" VariantName="Hovedsignalbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Forsignalbalisegruppe" VariantName="Forsignalbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Repeterbalisegruppe" VariantName="Repeterbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Sporvekselbalisegruppe" VariantName="Sporvekselbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Hastighetsbalisegruppe" VariantName="Hastighetsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Lenkingsbalisegruppe" VariantName="Lenkingsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Signalhøyningsbalisegruppe" VariantName="Signalhøyningsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="ET-balisegruppe" VariantName="ET-balisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Grensebalisegruppe" VariantName="Grensebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Radioområdebalisegruppe" VariantName="Radioområdebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject Name="Diversebalisegruppe" VariantName="Diversebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="10" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -23008,7 +23016,7 @@ return s</Data>
       <Variant Name="Tom/styrt" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -23019,7 +23027,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." DefaultValue="False" Category="Presentation" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="true" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -23060,7 +23068,7 @@ return s</Data>
 				{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
       <SymbolAttribute Tag="TEKSTOVER">
         <Value>{{TextAbove}}</Value>
       </SymbolAttribute>
@@ -23079,7 +23087,7 @@ return s</Data>
 				{% endif %}
 				Metric
 			</BlockNameFormat>
-      <Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
+      <Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
     </SymbolDefinition>
     <SymbolDefinition RotationCenter="OwnPosition" DefaultBlockName="NO-BN-2D-JBTRC_INNSETTINGSPUNKT-Schematic" AllowSymbolMove="false" DoNotIncludeInSymbolFrame="true">
       <Rotation DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
@@ -23090,25 +23098,25 @@ return s</Data>
       </Attribute>
     </Annotation3DTagDefinition>
     <InsertPointObject DisplayName="Balise fylt/fast" Name="Fylt/fast" VariantName="Fylt/fast" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-FYLT-FAST-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Balise fylt/styrt" Name="Fylt/styrt" VariantName="Fylt/styrt" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-FYLT-STYRT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Balise tom/fast" Name="Tom/fast" VariantName="Tom/fast" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-FAST-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
     </InsertPointObject>
     <InsertPointObject DisplayName="Balise tom/styrt" Name="Tom/styrt" VariantName="Tom/styrt" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-STYRT-{{SymbolMode}}" AskForAttachment="false" AskMatchPosition="false" InsertOnce="false" SnapToAlignment="true" SnapDistance="4e-4" SnapSensitivityDistance="3" DefaultSnapMode="Alignment">
-      <SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+      <SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="true" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" EnableDirectionSetting="false" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -23248,7 +23256,7 @@ return s</Data>
       <Variant Name="Fiktivt sluttpunkt for togvei og skiftevei" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -23321,7 +23329,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -23368,7 +23376,7 @@ return s</Data>
         <SetValue Key="switchable" Value="false" />
         <SetValue Key="virtual" Value="false" />
         <SetValue Key="ruleCode" Value="" />
-        <SetValue Key="Yokemounted" Value="False" />
+        <SetValue Key="PortalMounted" Value="False" />
       </Variant>
       <Variant Name="ERTMS E35 Stoppskilt, sidestilt med dverg">
         <SetValue Key="type" Value="main" />
@@ -23376,7 +23384,7 @@ return s</Data>
         <SetValue Key="switchable" Value="false" />
         <SetValue Key="virtual" Value="false" />
         <SetValue Key="ruleCode" Value="" />
-        <SetValue Key="Yokemounted" Value="False" />
+        <SetValue Key="PortalMounted" Value="False" />
       </Variant>
       <Variant Name="ERTMS E35 Stoppskilt, sidestilt med lav dverg">
         <SetValue Key="type" Value="main" />
@@ -23384,7 +23392,7 @@ return s</Data>
         <SetValue Key="switchable" Value="false" />
         <SetValue Key="virtual" Value="false" />
         <SetValue Key="ruleCode" Value="" />
-        <SetValue Key="Yokemounted" Value="False" />
+        <SetValue Key="PortalMounted" Value="False" />
       </Variant>
       <Variant Name="ERTMS E35 Stoppskilt, over sporet">
         <SetValue Key="type" Value="main" />
@@ -23392,7 +23400,7 @@ return s</Data>
         <SetValue Key="switchable" Value="false" />
         <SetValue Key="virtual" Value="false" />
         <SetValue Key="ruleCode" Value="" />
-        <SetValue Key="Yokemounted" Value="True" />
+        <SetValue Key="PortalMounted" Value="True" />
       </Variant>
       <Variant Name="ERTMS E35 Stoppskilt, over sporet med dverg">
         <SetValue Key="type" Value="main" />
@@ -23400,7 +23408,7 @@ return s</Data>
         <SetValue Key="switchable" Value="false" />
         <SetValue Key="virtual" Value="false" />
         <SetValue Key="ruleCode" Value="" />
-        <SetValue Key="Yokemounted" Value="True" />
+        <SetValue Key="PortalMounted" Value="True" />
       </Variant>
       <Variant Name="ERTMS dverg">
         <SetValue Key="type" Value="shunting" />
@@ -23408,11 +23416,11 @@ return s</Data>
         <SetValue Key="switchable" Value="false" />
         <SetValue Key="virtual" Value="false" />
         <SetValue Key="ruleCode" Value="" />
-        <SetValue Key="Yokemounted" Value="False" />
+        <SetValue Key="PortalMounted" Value="False" />
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -23423,7 +23431,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -23449,7 +23457,7 @@ return s</Data>
 				{% elsif Variant contains 'over' %}ERTMS-E35-OVER
 				{% endif %}
 				{% if Variant contains 'dverg' %}DS{% endif %}
-				{% if Yokemounted %}AAK{% endif %}
+				{% if PortalMounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
       <Rotation AddAngle="{% if dir == 'up' %}{{270.0|plus:AngularOffset}}               {% elsif dir == 'down' %}{{90.0|plus:AngularOffset}}               {% elsif dir == 'both' and RightSided %}{{180.0|plus:AngularOffset}}               {% elsif dir == 'both' and LeftSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and RightSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and LeftSided %}{{180.0|plus:AngularOffset}}               {% else %}45.0               {% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
@@ -23502,7 +23510,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -23559,16 +23567,16 @@ return s</Data>
 				function _JBTSA_SIG_ertms_Offset3dZ(_position)
 					
 					if Variant == "ERTMS E35 Stoppskilt, sidestilt med dverg" then
-						return Yokemounted and -3.2 or 1.9
+						return PortalMounted and -3.2 or 1.9
 					
 					elseif Variant == "ERTMS E35 Stoppskilt, sidestilt med lav dverg" then
-						return Yokemounted and -3.0 or 0.2
+						return PortalMounted and -3.0 or 0.2
 						
 					elseif Variant == "ERTMS dverg" then
-						return Yokemounted and -2.6 or 1.3
+						return PortalMounted and -2.6 or 1.3
 
 					else
-						return Yokemounted and -3.0 or 3.3
+						return PortalMounted and -3.0 or 3.3
 					end
 				end
 			</Formula>
@@ -23612,7 +23620,7 @@ return s</Data>
       <Variant Name="Sammensatt signal" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -23623,7 +23631,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="SpreadingLens" DisplayName="Spredelinse" Description="The 'SpreadingLens' custom property [Ja,-] defines whether the signal shall use spreading lenses (default: '-')." DefaultValue="-" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Ja</Value>
@@ -23742,7 +23750,7 @@ return s</Data>
 			{% if OpticalSpeedSignal == 'Ja' %}LHS{% endif %}
 			{% if BrakeTestSignal == 'Ja' %}BPS{% endif %}
 			{% if DepartureSignal == 'Ja' %}AVS{% endif %}
-			{% if Yokemounted %}AAK{% endif %}
+			{% if PortalMounted %}AAK{% endif %}
 			{{SymbolMode}}
 			</BlockNameFormat>
       <Rotation AddAngle="{% if dir == 'up' %}{{270.0|plus:AngularOffset}}               {% elsif dir == 'down' %}{{270.0|plus:AngularOffset}}               {% elsif dir == 'both' and RightSided %}{{180.0|plus:AngularOffset}}               {% elsif dir == 'both' and LeftSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and RightSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and LeftSided %}{{180.0|plus:AngularOffset}}               {% else %}45.0               {% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="true" />
@@ -24624,7 +24632,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -24704,7 +24712,7 @@ return s</Data>
 					if (DepartureSignal ~= "-") then t = t.."-AVS" end --Avgangssignal
 					if (BrakeTestSignal ~= "-") then t = t.."-BPS" end --Bremseprøvesignal
 					if Sunscreen == "-" then t = t.."-UTEN-SKJERM" end
-					if Yokemounted then t = t.."-ÅK" end
+					if PortalMounted then t = t.."-ÅK" end
 					if KneeTowardsTrack then if KneeTowardsTrack ~= "-" then t = t..(RightSided and "-VKNE" or "-HKNE") end end
 					if t:match("%-NSI63%-DS") and not t:match("ÅK") then t = t.."-2000" end --Add '-2000' pole total length to shunting signal if free-standing shunting signal
 					return t
@@ -24730,7 +24738,7 @@ return s</Data>
       <Variant Name="Togsporsignal 2-begrep, sidestilt" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -24741,7 +24749,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -24783,7 +24791,7 @@ return s</Data>
 					{% endif %}
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if Yokemounted %}AAK{% endif %}
+				{% if PortalMounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
       <Rotation AddAngle="{% if dir == 'up' %}{{270.0|plus:AngularOffset}}               {% elsif dir == 'down' %}{{90.0|plus:AngularOffset}}               {% elsif dir == 'both' and RightSided %}{{180.0|plus:AngularOffset}}               {% elsif dir == 'both' and LeftSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and RightSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and LeftSided %}{{180.0|plus:AngularOffset}}               {% else %}45.0               {% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
@@ -24842,7 +24850,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -24952,7 +24960,7 @@ return s</Data>
       <Variant Name="Frittstående Høyt Skiftesignal med Middelkontroll" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -24963,7 +24971,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -24985,7 +24993,7 @@ return s</Data>
                 {% elsif Variant == 'Frittstående Høyt Skiftesignal med Middelkontroll' %}ZS-MKS
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if Yokemounted %}AAK{% endif %}
+				{% if PortalMounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
       <Rotation AddAngle="{% if dir == 'up' %}{{270.0|plus:AngularOffset}}               {% elsif dir == 'down' %}{{90.0|plus:AngularOffset}}               {% elsif dir == 'both' and RightSided %}{{180.0|plus:AngularOffset}}               {% elsif dir == 'both' and LeftSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and RightSided %}{{0.0|plus:AngularOffset}}               {% elsif dir == 'none' and LeftSided %}{{180.0|plus:AngularOffset}}               {% else %}45.0               {% endif %}" DoNotRotateWithAlignment="false" Add180DegreesIfDirIsDown="false" />
@@ -25007,7 +25015,7 @@ return s</Data>
       <SetValue Key="switchable" Value="true" />
       <SetValue Key="virtual" Value="false" />
       <SetValue Key="ruleCode" Value="" />
-      <SetValue Key="Yokemounted" Value="False" />
+      <SetValue Key="PortalMounted" Value="False" />
       <JigSymbolAppearance RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="-90" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <Rotation RotateIfRightSideOfAlignment="false" RotateIfLeftSideOfAlignment="false" RotateWithUcs="false" MirrorAboutJigYAxisIfRightSideOfAlignment="false" MirrorAboutJigYAxisIfLeftSideOfAlignment="false" MirrorAboutJigXAxisIfRightSideOfAlignment="false" MirrorAboutJigXAxisIfLeftSideOfAlignment="false" AddAngle="-90" EnableDirectionSetting="true" DoNotRotateWithAlignment="false" />
       <OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
@@ -25027,7 +25035,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -25101,7 +25109,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -25112,7 +25120,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="SpreadingLens" DisplayName="Spredelinse" Description="The 'SpreadingLens' custom property [Ja,-] defines whether the signal shall use spreading lenses (default: '-')." DefaultValue="-" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Ja</Value>
@@ -25169,7 +25177,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -25225,7 +25233,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -25236,7 +25244,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="SpreadingLens" DisplayName="Spredelinse" Description="The 'SpreadingLens' custom property [Ja,-] defines whether the signal shall use spreading lenses (default: '-')." DefaultValue="-" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Ja</Value>
@@ -25294,7 +25302,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -25349,7 +25357,7 @@ return s</Data>
       <Variant Name="Planovergang, forsignal" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -25360,7 +25368,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="SpreadingLens" DisplayName="Spredelinse" Description="The 'SpreadingLens' custom property [Ja,-] defines whether the signal shall use spreading lenses (default: '-')." DefaultValue="-" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Ja</Value>
@@ -25428,7 +25436,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -25508,7 +25516,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -25572,7 +25580,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -25629,7 +25637,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -25711,7 +25719,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -25795,7 +25803,7 @@ return s</Data>
       <Variant Name="Lysarmatur" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26020,7 +26028,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26368,7 +26376,7 @@ return s</Data>
       <Variant Name="Fordelingsskap" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26497,7 +26505,7 @@ return s</Data>
       <Variant Name="Gruppeskap" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26590,7 +26598,7 @@ return s</Data>
       <Variant Name="Togvarmepost" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26678,7 +26686,7 @@ return s</Data>
       <Variant Name="Transformator" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26766,7 +26774,7 @@ return s</Data>
       <Variant Name="UPS fordeler" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26953,7 +26961,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -26964,7 +26972,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -26998,7 +27006,7 @@ return s</Data>
 					{% elsif Variant == 'E36 Level crossing, announcement' %}LEVEL-CROSSING-ANNOUNCE
 					{% else %}BAD_Variant
 					{% endif %}
-					{% if Yokemounted %}YOKE{% endif %}
+					{% if PortalMounted %}YOKE{% endif %}
 				{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
@@ -27124,7 +27132,7 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula>
+      <Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="Rotation3D.Z" IsModelCheck="false">
@@ -27306,7 +27314,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -27546,7 +27554,7 @@ return s</Data>
       <Signature>String _JBTSA_MSS_E101_Offset3dZ()</Signature>
       <Formula>
 				function _JBTSA_MSS_E101_Offset3dZ()
-					return Yokemounted and -1.5 or 1.5
+					return PortalMounted and -1.5 or 1.5
 				end
 			</Formula>
     </LuaFunction>
@@ -27583,7 +27591,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -27760,7 +27768,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -27870,9 +27878,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -27946,7 +27954,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -28001,9 +28009,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -28091,7 +28099,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -28178,9 +28186,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -28280,7 +28288,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -28440,9 +28448,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -28600,7 +28608,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -28664,9 +28672,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -28775,7 +28783,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -28910,9 +28918,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -28985,7 +28993,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -29054,9 +29062,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -29126,7 +29134,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -29201,9 +29209,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -29293,7 +29301,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -29384,9 +29392,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -29457,7 +29465,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -29533,9 +29541,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -29660,7 +29668,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -29807,7 +29815,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -29870,9 +29878,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -29948,7 +29956,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -30048,9 +30056,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -30138,12 +30146,12 @@ return s</Data>
     <Variants>
       <Variant Name="Spornummer">
         <SetValue Key="Model3DName" Value="NO-BN-3D-KO-SKT-SKILT-SPORNUMMER" />
-        <SetValue Key="Yokemounted" Value="True" />
+        <SetValue Key="PortalMounted" Value="True" />
         <SetValue Key="code" Value="38" />
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -30154,7 +30162,7 @@ return s</Data>
     <CustomProperty DataType="String" Name="Var7" DisplayName="Var7" Description="The 'Var7' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var8" DisplayName="Var8" Description="The 'Var8' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var9" DisplayName="Var9" Description="The 'Var9' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
-    <CustomProperty DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." DefaultValue="False" Category="Custom properties" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="Enumeration" Name="Discipline" DisplayName="Discipline" Description="The custom 'Discipline' attribute [Felles | Skilt | Overbygning | Underbygning | Kontaktledning | Signal | Tele | Lavspent] identifies the discpline owning the object." DefaultValue="" Category="General" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false">
       <Values>
         <Value>Felles</Value>
@@ -30207,9 +30215,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -30325,7 +30333,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -30549,7 +30557,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -30674,7 +30682,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -30735,9 +30743,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -30811,7 +30819,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -30866,9 +30874,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -30952,7 +30960,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -31097,9 +31105,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -31192,7 +31200,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -31260,9 +31268,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -31335,7 +31343,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -31414,9 +31422,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -31492,7 +31500,7 @@ return s</Data>
       <Variant Name="Signal 75D Senk sporrenser" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -31561,9 +31569,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -31665,7 +31673,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -31770,9 +31778,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -31933,7 +31941,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -32086,9 +32094,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -32168,7 +32176,7 @@ return s</Data>
       <Variant Name="Skilt Rømningsavstand mot høyre" />
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -32258,9 +32266,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -32351,7 +32359,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -32406,9 +32414,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -32488,7 +32496,7 @@ return s</Data>
       </Variant>
     </Variants>
     <AlignmentSystems DefaultSystemName="No data" />
-    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="3D" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
+    <CustomProperty DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." DefaultValue="0.0" Category="Aligned object" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var0" DisplayName="Var0" Description="The 'Var0' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var1" DisplayName="Var1" Description="The 'Var1' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
     <CustomProperty DataType="String" Name="Var2" DisplayName="Var2" Description="The 'Var2' custom property [String] is a local variable for free use." DefaultValue="" Category="Local variables" ReadOnly="false" StandardValuesFromLuaFormula="false" StandardValuesExclusive="false" InvertOnAlignmentReverse="false" HideFromUser="false" />
@@ -32558,9 +32566,9 @@ return s</Data>
       <Symbol>_noSymbol</Symbol>
     </LuaExpression>
     <LuaExpression Name="RelativeElevation" IsModelCheck="false">
-      <Formula>if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+      <Formula>if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -34691,9 +34699,9 @@ end
 				elseif Variant:find("Baliseskilt") then return 0.0 --Mounted on platform element's side towards track, at A-balise
 			
 				--May be hanging from yoke, othwerwise on own pole:
-				elseif Variant:find("Spornummer") then return Yokemounted and -1 or 3.5
-				-- TODO elseif Variant:find("E34") then return Yokemounted and -1 or 3.5 --ERTMS Stedsskilt
-				elseif Variant:find("E35") then return Yokemounted and -1 or 3.5 --ERTMS Stoppskilt
+				elseif Variant:find("Spornummer") then return PortalMounted and -1 or 3.5
+				-- TODO elseif Variant:find("E34") then return PortalMounted and -1 or 3.5 --ERTMS Stedsskilt
+				elseif Variant:find("E35") then return PortalMounted and -1 or 3.5 --ERTMS Stoppskilt
 			
 				--To be read by train driver sitting in train, AND by walking people:
 				elseif Variant:find("1000V") then return 2.5
@@ -35592,11 +35600,11 @@ end
 		</Formula>
   </LuaFunction>
   <LuaFunction Name="NOBN_trk_getSwitchLabelItem1()" Description="Returns the Fouling Point and Stock Rail joint reference mileages for a related switch." ReturnType="String" HideFromUser="false">
-    <Signature>String NOBN_trk_getSwitchLabelItem1([Boolean KmStigerMotVenstre])</Signature>
+    <Signature>String NOBN_trk_getSwitchLabelItem1([Boolean MileageIncreasesTowardsLeft])</Signature>
     <Formula>
-			function NOBN_trk_getSwitchLabelItem1(KmStigerMotVenstre)
-				if KmStigerMotVenstre == nil then 
-					KmStigerMotVenstre = false
+			function NOBN_trk_getSwitchLabelItem1(MileageIncreasesTowardsLeft)
+				if MileageIncreasesTowardsLeft == nil then 
+					MileageIncreasesTowardsLeft = false
 				end
 				local r, v, fp, ss
 				r = Relations["Er etikett for anything"]
@@ -35614,13 +35622,13 @@ end
 					else 
 						fprm = fp[0].Branch1.ReferenceMileage  --Fouling point reference mileage
 						if srjrm &lt; fprm then 
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "Km."..RC__toKm(fprm).."/"..RC__toKm(srjrm)
 							else
 								return "Km."..RC__toKm(srjrm).."/"..RC__toKm(fprm)
 							end
 						else
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "Km."..RC__toKm(srjrm).."/"..RC__toKm(fprm)
 							else
 								return "Km."..RC__toKm(fprm).."/"..RC__toKm(srjrm)
@@ -35632,11 +35640,11 @@ end
 		</Formula>
   </LuaFunction>
   <LuaFunction Name="NOBN_trk_getSwitchLabelItem2()" Description="Returns the related switch's name." ReturnType="String" HideFromUser="false">
-    <Signature>String NOBN_trk_getSwitchLabelItem2([Boolean KmStigerMotVenstre])</Signature>
+    <Signature>String NOBN_trk_getSwitchLabelItem2([Boolean MileageIncreasesTowardsLeft])</Signature>
     <Formula>
-			function NOBN_trk_getSwitchLabelItem2(KmStigerMotVenstre)
-				if KmStigerMotVenstre == nil then 
-					KmStigerMotVenstre = false
+			function NOBN_trk_getSwitchLabelItem2(MileageIncreasesTowardsLeft)
+				if MileageIncreasesTowardsLeft == nil then 
+					MileageIncreasesTowardsLeft = false
 				end
 				local s, r, n, v, fp, ss
 				s = "Er etikett for anything"
@@ -35655,13 +35663,13 @@ end
 					else
 						fprm = fp[0].Branch1.ReferenceMileage  --Fouling point reference mileage
 						if srjrm &lt; fprm then 
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "Mid/SS "..v.Code
 							else
 								return "SS/Mid "..v.Code
 							end
 						else
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "SS/Mid "..v.Code
 							else
 								return "Mid/SS "..v.Code
@@ -36096,7 +36104,7 @@ end
 					startY = geoCoord.Y + SymbolOffset.Y
 					endX = closest.geoCoord.X + closest.SymbolOffset.X
 					endY = closest.geoCoord.Y + closest.SymbolOffset.Y
-					return math.deg(math.atan(endY - startY, endX - startX)) + (KmStigerMotVenstre and 180 or 0)
+					return math.deg(math.atan(endY - startY, endX - startX)) + (MileageIncreasesTowardsLeft and 180 or 0)
 				end
 			end
 		</Formula>
@@ -36131,7 +36139,7 @@ end
 					startY = geoCoord.Y + SymbolOffset.Y
 					endX = closest2.geoCoord.X + closest2.SymbolOffset.X
 					endY = closest2.geoCoord.Y + closest2.SymbolOffset.Y
-					return math.deg(math.atan(endY - startY, endX - startX)) + (KmStigerMotVenstre and 180 or 0)
+					return math.deg(math.atan(endY - startY, endX - startX)) + (MileageIncreasesTowardsLeft and 180 or 0)
 				end
 			end
 		</Formula>
@@ -37016,7 +37024,7 @@ function NOBN_sig_chkSafetyDistanceFromSignalToOcsMast()
 	local omit = false
 
 	if RcType == "JBTSA_ERT ERTMS-signal" then
-		if Yokemounted then
+		if PortalMounted then
 			return "WARNING - Check manually that no OCS yoke is within safety distance from markerboard in yoke.",_warning
 		else
 			return "OK - Markerboard on the ground - Safety distance to OCS mast not relevant.",_ok
@@ -37067,7 +37075,7 @@ end
 				side = side and side:lower() or "(no arg)"				
 				if side ~= "left" and side ~= "right" then return "*** ERROR Function should be called with argument 'right' or 'left' ["..side.."]." end
 				if Alignment == nil then return "UNFINISHED - Signal must first be assigned to an alignment to deduce its own direction." end
-				if (DwarfSignal == "Ja" and MainSignal == "-" and Yokemounted) then return "WARNING - Shunting signal mounted in yoke. Please do manual check.",_warning end
+				if (DwarfSignal == "Ja" and MainSignal == "-" and PortalMounted) then return "WARNING - Shunting signal mounted in yoke. Please do manual check.",_warning end
 --2021-01-12 CLFEY: No warning just if high above but outside lateral problem distance.
 --if (RelativeElevation &gt; 0.3) then return "WARNING - Signal mounted outside normal elevations. Please do manual check.",_warning end
 				tracks = getClosestAlignments("JBTKO_SPO Spor"):filter(function (x) return (side:upper() == "RIGHT" and 1 or -1) * getAlignmentInfo(x.id).DistanceToAlignment &lt; 0 end)

--- a/NO-BN/DNA/_SRC/NO-BN-Balises.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Balises.xml
@@ -568,14 +568,14 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="ETCS L2 balisegruppe, dobbel" DisplayBlockName="NO-BN-2D-JBTSA_ETC-ETCS-BALISEGRUPPE-DOBBEL-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="true" >
@@ -728,18 +728,18 @@
 				DefaultSnapMode="Point" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="false" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="ETCS-balise, styrt" DisplayBlockName="NO-BN-2D-JBTSA_ETB-ETCS-BALISE-STYRT-{{SymbolMode}}" 
 				DefaultSnapMode="Point" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="false" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ETB-ETCS-BALISE
 				{% if Variant contains 'fast' %}FAST
@@ -759,7 +759,7 @@
 		<!-- Metric info -->
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="false" >
 			<!--Note: cosisnegative (RC built-in filter for DotLiquid) returns 'True' with an uppercase T-->
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ETB-ETCS-BALISE
 				{% if Variant contains 'fast' %}FAST
@@ -869,81 +869,81 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Forsignalbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Repeterbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Sporvekselbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Hastighetsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Lenkingsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Signalhøyningsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="ET-balisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Grensebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Radioområdebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Diversebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 		</SymbolDefinition>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTRC_INNSETTINGSPUNKT-Schematic" />
@@ -1120,32 +1120,32 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Fylt/styrt" DisplayName="Balise fylt/styrt" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-FYLT-STYRT-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Tom/fast" DisplayName="Balise tom/fast" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-FAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Tom/styrt" DisplayName="Balise tom/styrt" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-STYRT-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-FAST-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ATB-NSS-BALISE
 				{% if Variant == 'Fylt/fast'or Variant == 'Fylt/styrt' %}FYLT
@@ -1167,7 +1167,7 @@
 		<!-- Metric info -->
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-FAST-Metric" AllowSymbolMove="false" >
 			<!--Note: cosisnegative (RC built-in filter for DotLiquid) returns 'True' with an uppercase T-->
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ATB-NSS-BALISE
 				{% if Variant == 'Fylt/fast'or Variant == 'Fylt/styrt' %}FYLT

--- a/NO-BN/DNA/_SRC/NO-BN-Balises.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Balises.xml
@@ -568,14 +568,14 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="ETCS L2 balisegruppe, dobbel" DisplayBlockName="NO-BN-2D-JBTSA_ETC-ETCS-BALISEGRUPPE-DOBBEL-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="true" >
@@ -728,18 +728,18 @@
 				DefaultSnapMode="Point" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="false" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="ETCS-balise, styrt" DisplayBlockName="NO-BN-2D-JBTSA_ETB-ETCS-BALISE-STYRT-{{SymbolMode}}" 
 				DefaultSnapMode="Point" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="false" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ETB-ETCS-BALISE
 				{% if Variant contains 'fast' %}FAST
@@ -759,7 +759,7 @@
 		<!-- Metric info -->
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="false" >
 			<!--Note: cosisnegative (RC built-in filter for DotLiquid) returns 'True' with an uppercase T-->
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ETB-ETCS-BALISE
 				{% if Variant contains 'fast' %}FAST
@@ -869,81 +869,81 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Forsignalbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Repeterbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Sporvekselbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Hastighetsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Lenkingsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Signalhøyningsbalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="ET-balisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Grensebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Radioområdebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="Diversebalisegruppe" DisplayBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="10" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance /> 
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_ATC-NSS-BALISEGRUPPE-STANDARD-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 		</SymbolDefinition>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTRC_INNSETTINGSPUNKT-Schematic" />
@@ -1120,32 +1120,32 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Fylt/styrt" DisplayName="Balise fylt/styrt" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-FYLT-STYRT-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Tom/fast" DisplayName="Balise tom/fast" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-FAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Tom/styrt" DisplayName="Balise tom/styrt" DisplayBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-STYRT-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance RotateWithUcs="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-FAST-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ATB-NSS-BALISE
 				{% if Variant == 'Fylt/fast'or Variant == 'Fylt/styrt' %}FYLT
@@ -1167,7 +1167,7 @@
 		<!-- Metric info -->
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_ATB-NSS-BALISE-TOM-FAST-Metric" AllowSymbolMove="false" >
 			<!--Note: cosisnegative (RC built-in filter for DotLiquid) returns 'True' with an uppercase T-->
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTSA_ATB-NSS-BALISE
 				{% if Variant == 'Fylt/fast'or Variant == 'Fylt/styrt' %}FYLT

--- a/NO-BN/DNA/_SRC/NO-BN-BoardsAndPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-BoardsAndPoles.xml
@@ -209,7 +209,7 @@
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_SYMBOLFRAME" />
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -437,7 +437,7 @@
 				{% elsif Variant == 'E39 Frost gate' %}FROST-GATE
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if PortalMounted %}YOKE{% endif %}
+				{% if Yokemounted %}YOKE{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -599,7 +599,7 @@
 		<Constructor>String _JBTSA_MSS_E101_Offset3dZ()</Constructor>
 			<Formula>
 				function _JBTSA_MSS_E101_Offset3dZ()
-					return PortalMounted and -1.5 or 1.5
+					return Yokemounted and -1.5 or 1.5
 				end
 			</Formula>
 		</LuaFunction>
@@ -2746,7 +2746,7 @@
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_SYMBOLFRAME" />
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___VERTICAL_AND_STACKED___TRK" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___BNP" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -2762,7 +2762,7 @@
 		<Variants>
 			<Variant Name="Spornummer" >
 				<SetValue Key="Model3DName" Value="NO-BN-3D-KO-SKT-SKILT-SPORNUMMER" />
-				<SetValue Key="PortalMounted" Value="True" />
+				<SetValue Key="Yokemounted" Value="True" />
 				<SetValue Key="code" Value="38" />
 			</Variant>
 		</Variants>

--- a/NO-BN/DNA/_SRC/NO-BN-BoardsAndPoles.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-BoardsAndPoles.xml
@@ -209,7 +209,7 @@
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_SYMBOLFRAME" />
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -437,7 +437,7 @@
 				{% elsif Variant == 'E39 Frost gate' %}FROST-GATE
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if Yokemounted %}YOKE{% endif %}
+				{% if PortalMounted %}YOKE{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -599,7 +599,7 @@
 		<Constructor>String _JBTSA_MSS_E101_Offset3dZ()</Constructor>
 			<Formula>
 				function _JBTSA_MSS_E101_Offset3dZ()
-					return Yokemounted and -1.5 or 1.5
+					return PortalMounted and -1.5 or 1.5
 				end
 			</Formula>
 		</LuaFunction>
@@ -2746,7 +2746,7 @@
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_SYMBOLFRAME" />
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___VERTICAL_AND_STACKED___TRK" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___BNP" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -2762,7 +2762,7 @@
 		<Variants>
 			<Variant Name="Spornummer" >
 				<SetValue Key="Model3DName" Value="NO-BN-3D-KO-SKT-SKILT-SPORNUMMER" />
-				<SetValue Key="Yokemounted" Value="True" />
+				<SetValue Key="PortalMounted" Value="True" />
 				<SetValue Key="code" Value="38" />
 			</Variant>
 		</Variants>

--- a/NO-BN/DNA/_SRC/NO-BN-CommonObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-CommonObjects.xml
@@ -268,11 +268,11 @@
 		<InsertPointObject VariantName="Watch" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>      
 		
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}</BlockNameFormat>
 			<SymbolAttribute Tag="W" >
 				<Value>{{Text}}</Value>
@@ -397,14 +397,14 @@ end
 		</Variants>
 
 		<InsertPointObject VariantName="KOF Koordinatliste" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic" >
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="SymbolFrame" Value="Watch" />
 		</InsertPointObject>      
 		
 		<LuaExpression Name="Text" ><Formula>NOBN_com_getKof05Records(KofThemeCode,KofSearchArea)</Formula></LuaExpression>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}</BlockNameFormat>
 			<SymbolAttribute Tag="W" >
 				<Value>{{Text}}</Value>
@@ -774,14 +774,14 @@ end
 		<InsertPointObject VariantName="Hovedspor" DisplayName="Sporbruk" DisplayBlockName="NO-BN-2D-JBTRC_SEKSJON-INNSETTING-SYMBOL-Schematic" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="SymbolFrame" Value="Symbolramme-R2.75" />
 			<SetValue Key="DelimiterType" Value="JBTFE_DIV Sporbrukgrense" />
 		</InsertPointObject>
 		
 		<!-- NB - The RailCOMPLETE SymbolFrame forms the frame around the section's visible text. -->
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<SymbolAttribute Tag="X" >
 				<Value>{{Variant}}</Value>
 			</SymbolAttribute>
@@ -831,7 +831,7 @@ end
 				function _JBTFE_DIV_sporbrukgrense_code()
 					first = DownSections.Count == 0  and "-" or DownSections[0].Code
 					second = UpSections.Count == 0  and "-" or UpSections[0].Code
-					if MileageIncreasesTowardsLeft then	first,second = second,first end
+					if KmStigerMotVenstre then	first,second = second,first end
 					return "(" .. first .. "/" .. second .. ")"
 				end
 			</Formula>
@@ -845,7 +845,7 @@ end
 				function _JBTFE_DIV_sporbrukgrense_objectInfo()
 					first = DownSections.Count == 0  and "-" or DownSections[0].Variant
 					second = UpSections.Count == 0  and "-" or UpSections[0].Variant
-					if MileageIncreasesTowardsLeft then	first,second = second,first end
+					if KmStigerMotVenstre then	first,second = second,first end
 					return "Sporbruk: " .. first .. "/" .. second
 				end
 			</Formula>
@@ -855,12 +855,12 @@ end
 				SnapToAlignment="true" SnapDistance="0.0" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="dir" Value="both" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_MRK-MARKOER-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >NO-BN-2D-JBTFE_MRK-MARKOER-{{SymbolMode}}</BlockNameFormat>
 			<SymbolAttribute Tag="FARGE" >
 				<Value>{{code}}</Value>

--- a/NO-BN/DNA/_SRC/NO-BN-CommonObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-CommonObjects.xml
@@ -268,11 +268,11 @@
 		<InsertPointObject VariantName="Watch" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="3" SnapSensitivityDistance="6" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>      
 		
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}</BlockNameFormat>
 			<SymbolAttribute Tag="W" >
 				<Value>{{Text}}</Value>
@@ -397,14 +397,14 @@ end
 		</Variants>
 
 		<InsertPointObject VariantName="KOF Koordinatliste" DisplayBlockName="NO-BN-2D-JBTRC_WATCH-INNSETTING-SYMBOL-Schematic" >
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="SymbolFrame" Value="Watch" />
 		</InsertPointObject>      
 		
 		<LuaExpression Name="Text" ><Formula>NOBN_com_getKof05Records(KofThemeCode,KofSearchArea)</Formula></LuaExpression>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >NO-BN-2D-JBTFE_WCH-WATCH-{{SymbolMode}}</BlockNameFormat>
 			<SymbolAttribute Tag="W" >
 				<Value>{{Text}}</Value>
@@ -774,14 +774,14 @@ end
 		<InsertPointObject VariantName="Hovedspor" DisplayName="Sporbruk" DisplayBlockName="NO-BN-2D-JBTRC_SEKSJON-INNSETTING-SYMBOL-Schematic" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="SymbolFrame" Value="Symbolramme-R2.75" />
 			<SetValue Key="DelimiterType" Value="JBTFE_DIV Sporbrukgrense" />
 		</InsertPointObject>
 		
 		<!-- NB - The RailCOMPLETE SymbolFrame forms the frame around the section's visible text. -->
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<SymbolAttribute Tag="X" >
 				<Value>{{Variant}}</Value>
 			</SymbolAttribute>
@@ -831,7 +831,7 @@ end
 				function _JBTFE_DIV_sporbrukgrense_code()
 					first = DownSections.Count == 0  and "-" or DownSections[0].Code
 					second = UpSections.Count == 0  and "-" or UpSections[0].Code
-					if KmStigerMotVenstre then	first,second = second,first end
+					if MileageIncreasesTowardsLeft then	first,second = second,first end
 					return "(" .. first .. "/" .. second .. ")"
 				end
 			</Formula>
@@ -845,7 +845,7 @@ end
 				function _JBTFE_DIV_sporbrukgrense_objectInfo()
 					first = DownSections.Count == 0  and "-" or DownSections[0].Variant
 					second = UpSections.Count == 0  and "-" or UpSections[0].Variant
-					if KmStigerMotVenstre then	first,second = second,first end
+					if MileageIncreasesTowardsLeft then	first,second = second,first end
 					return "Sporbruk: " .. first .. "/" .. second
 				end
 			</Formula>
@@ -855,12 +855,12 @@ end
 				SnapToAlignment="true" SnapDistance="0.0" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="dir" Value="both" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_MRK-MARKOER-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >NO-BN-2D-JBTFE_MRK-MARKOER-{{SymbolMode}}</BlockNameFormat>
 			<SymbolAttribute Tag="FARGE" >
 				<Value>{{code}}</Value>

--- a/NO-BN/DNA/_SRC/NO-BN-Labels.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Labels.xml
@@ -16,11 +16,11 @@
 =========================================================================================================-->
 	<LuaFunction Name="NOBN_trk_getSwitchLabelItem1()" ReturnType="String"
 		Description="Returns the Fouling Point and Stock Rail joint reference mileages for a related switch." >
-		<Constructor>String NOBN_trk_getSwitchLabelItem1([Boolean MileageIncreasesTowardsLeft])</Constructor>
+		<Constructor>String NOBN_trk_getSwitchLabelItem1([Boolean KmStigerMotVenstre])</Constructor>
 		<Formula>
-			function NOBN_trk_getSwitchLabelItem1(MileageIncreasesTowardsLeft)
-				if MileageIncreasesTowardsLeft == nil then 
-					MileageIncreasesTowardsLeft = false
+			function NOBN_trk_getSwitchLabelItem1(KmStigerMotVenstre)
+				if KmStigerMotVenstre == nil then 
+					KmStigerMotVenstre = false
 				end
 				local r,v,fp,ss
 				r = Relations["Er etikett for anything"]
@@ -38,13 +38,13 @@
 					else 
 						fprm = fp[0].Branch1.ReferenceMileage  --Fouling point reference mileage
 						if srjrm &lt; fprm then 
-							if MileageIncreasesTowardsLeft then
+							if KmStigerMotVenstre then
 								return "Km."..RC__toKm(fprm).."/"..RC__toKm(srjrm)
 							else
 								return "Km."..RC__toKm(srjrm).."/"..RC__toKm(fprm)
 							end
 						else
-							if MileageIncreasesTowardsLeft then
+							if KmStigerMotVenstre then
 								return "Km."..RC__toKm(srjrm).."/"..RC__toKm(fprm)
 							else
 								return "Km."..RC__toKm(fprm).."/"..RC__toKm(srjrm)
@@ -60,11 +60,11 @@
 	
 	<LuaFunction Name="NOBN_trk_getSwitchLabelItem2()" ReturnType="String"
 		Description="Returns the related switch's name." >
-		<Constructor>String NOBN_trk_getSwitchLabelItem2([Boolean MileageIncreasesTowardsLeft])</Constructor>
+		<Constructor>String NOBN_trk_getSwitchLabelItem2([Boolean KmStigerMotVenstre])</Constructor>
 		<Formula>
-			function NOBN_trk_getSwitchLabelItem2(MileageIncreasesTowardsLeft)
-				if MileageIncreasesTowardsLeft == nil then 
-					MileageIncreasesTowardsLeft = false
+			function NOBN_trk_getSwitchLabelItem2(KmStigerMotVenstre)
+				if KmStigerMotVenstre == nil then 
+					KmStigerMotVenstre = false
 				end
 				local s,r,n,v,fp,ss
 				s = "Er etikett for anything"
@@ -83,13 +83,13 @@
 					else
 						fprm = fp[0].Branch1.ReferenceMileage  --Fouling point reference mileage
 						if srjrm &lt; fprm then 
-							if MileageIncreasesTowardsLeft then
+							if KmStigerMotVenstre then
 								return "Mid/SS "..v.Code
 							else
 								return "SS/Mid "..v.Code
 							end
 						else
-							if MileageIncreasesTowardsLeft then
+							if KmStigerMotVenstre then
 								return "SS/Mid "..v.Code
 							else
 								return "Mid/SS "..v.Code
@@ -205,37 +205,37 @@
 
 		<InsertPointObject DisplayName="Etikett A" VariantName="A-1-0-VRB-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-A-1-0-VRB-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett B" VariantName="B-1-0-HLT-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-B-1-0-HRB-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett C" VariantName="C-1-0-HLT-025" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-C-1-0-HRB-025-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett C (2 linjer)" VariantName="C-1-1-HLT-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-C-1-0-HRB-025-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett D" VariantName="D-1-1-HRB-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-1-HRB-025-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett D (3 linjer)" VariantName="D-1-2-HRB-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018-{{SymbolMode}}"  >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-A-1-0-VLB-018" AllowSymbolMove="true" >
 			<Rotation Add180DegreesIfDirIsDown="true" 
-						AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+						AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTFE_ETI-ETIKETT
 				{% if    Variant == 'A-1-0-VLB-018' %}A-1-0-VLB-018

--- a/NO-BN/DNA/_SRC/NO-BN-Labels.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Labels.xml
@@ -16,11 +16,11 @@
 =========================================================================================================-->
 	<LuaFunction Name="NOBN_trk_getSwitchLabelItem1()" ReturnType="String"
 		Description="Returns the Fouling Point and Stock Rail joint reference mileages for a related switch." >
-		<Constructor>String NOBN_trk_getSwitchLabelItem1([Boolean KmStigerMotVenstre])</Constructor>
+		<Constructor>String NOBN_trk_getSwitchLabelItem1([Boolean MileageIncreasesTowardsLeft])</Constructor>
 		<Formula>
-			function NOBN_trk_getSwitchLabelItem1(KmStigerMotVenstre)
-				if KmStigerMotVenstre == nil then 
-					KmStigerMotVenstre = false
+			function NOBN_trk_getSwitchLabelItem1(MileageIncreasesTowardsLeft)
+				if MileageIncreasesTowardsLeft == nil then 
+					MileageIncreasesTowardsLeft = false
 				end
 				local r,v,fp,ss
 				r = Relations["Er etikett for anything"]
@@ -38,13 +38,13 @@
 					else 
 						fprm = fp[0].Branch1.ReferenceMileage  --Fouling point reference mileage
 						if srjrm &lt; fprm then 
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "Km."..RC__toKm(fprm).."/"..RC__toKm(srjrm)
 							else
 								return "Km."..RC__toKm(srjrm).."/"..RC__toKm(fprm)
 							end
 						else
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "Km."..RC__toKm(srjrm).."/"..RC__toKm(fprm)
 							else
 								return "Km."..RC__toKm(fprm).."/"..RC__toKm(srjrm)
@@ -60,11 +60,11 @@
 	
 	<LuaFunction Name="NOBN_trk_getSwitchLabelItem2()" ReturnType="String"
 		Description="Returns the related switch's name." >
-		<Constructor>String NOBN_trk_getSwitchLabelItem2([Boolean KmStigerMotVenstre])</Constructor>
+		<Constructor>String NOBN_trk_getSwitchLabelItem2([Boolean MileageIncreasesTowardsLeft])</Constructor>
 		<Formula>
-			function NOBN_trk_getSwitchLabelItem2(KmStigerMotVenstre)
-				if KmStigerMotVenstre == nil then 
-					KmStigerMotVenstre = false
+			function NOBN_trk_getSwitchLabelItem2(MileageIncreasesTowardsLeft)
+				if MileageIncreasesTowardsLeft == nil then 
+					MileageIncreasesTowardsLeft = false
 				end
 				local s,r,n,v,fp,ss
 				s = "Er etikett for anything"
@@ -83,13 +83,13 @@
 					else
 						fprm = fp[0].Branch1.ReferenceMileage  --Fouling point reference mileage
 						if srjrm &lt; fprm then 
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "Mid/SS "..v.Code
 							else
 								return "SS/Mid "..v.Code
 							end
 						else
-							if KmStigerMotVenstre then
+							if MileageIncreasesTowardsLeft then
 								return "SS/Mid "..v.Code
 							else
 								return "Mid/SS "..v.Code
@@ -205,37 +205,37 @@
 
 		<InsertPointObject DisplayName="Etikett A" VariantName="A-1-0-VRB-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-A-1-0-VRB-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett B" VariantName="B-1-0-HLT-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-B-1-0-HRB-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett C" VariantName="C-1-0-HLT-025" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-C-1-0-HRB-025-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett C (2 linjer)" VariantName="C-1-1-HLT-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-C-1-0-HRB-025-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett D" VariantName="D-1-1-HRB-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-1-HRB-025-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject DisplayName="Etikett D (3 linjer)" VariantName="D-1-2-HRB-025-018" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018-{{SymbolMode}}"  >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-A-1-0-VLB-018" AllowSymbolMove="true" >
 			<Rotation Add180DegreesIfDirIsDown="true" 
-						AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+						AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTFE_ETI-ETIKETT
 				{% if    Variant == 'A-1-0-VLB-018' %}A-1-0-VLB-018

--- a/NO-BN/DNA/_SRC/NO-BN-Lua.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Lua.xml
@@ -647,9 +647,9 @@ end
 				elseif Variant:find("Baliseskilt") then return 0.0 --Mounted on platform element's side towards track, at A-balise
 			
 				--May be hanging from yoke, othwerwise on own pole:
-				elseif Variant:find("Spornummer") then return Yokemounted and -1 or 3.5
-				-- TODO elseif Variant:find("E34") then return Yokemounted and -1 or 3.5 --ERTMS Stedsskilt
-				elseif Variant:find("E35") then return Yokemounted and -1 or 3.5 --ERTMS Stoppskilt
+				elseif Variant:find("Spornummer") then return PortalMounted and -1 or 3.5
+				-- TODO elseif Variant:find("E34") then return PortalMounted and -1 or 3.5 --ERTMS Stedsskilt
+				elseif Variant:find("E35") then return PortalMounted and -1 or 3.5 --ERTMS Stoppskilt
 			
 				--To be read by train driver sitting in train, AND by walking people:
 				elseif Variant:find("1000V") then return 2.5

--- a/NO-BN/DNA/_SRC/NO-BN-Lua.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Lua.xml
@@ -647,9 +647,9 @@ end
 				elseif Variant:find("Baliseskilt") then return 0.0 --Mounted on platform element's side towards track, at A-balise
 			
 				--May be hanging from yoke, othwerwise on own pole:
-				elseif Variant:find("Spornummer") then return PortalMounted and -1 or 3.5
-				-- TODO elseif Variant:find("E34") then return PortalMounted and -1 or 3.5 --ERTMS Stedsskilt
-				elseif Variant:find("E35") then return PortalMounted and -1 or 3.5 --ERTMS Stoppskilt
+				elseif Variant:find("Spornummer") then return Yokemounted and -1 or 3.5
+				-- TODO elseif Variant:find("E34") then return Yokemounted and -1 or 3.5 --ERTMS Stedsskilt
+				elseif Variant:find("E35") then return Yokemounted and -1 or 3.5 --ERTMS Stoppskilt
 			
 				--To be read by train driver sitting in train, AND by walking people:
 				elseif Variant:find("1000V") then return 2.5

--- a/NO-BN/DNA/_SRC/NO-BN-OcsMasts.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsMasts.xml
@@ -275,7 +275,7 @@
 					startY = geoCoord.Y + SymbolOffset.Y
 					endX = closest.geoCoord.X + closest.SymbolOffset.X
 					endY = closest.geoCoord.Y + closest.SymbolOffset.Y
-					return math.deg(math.atan(endY - startY, endX - startX)) + (MileageIncreasesTowardsLeft and 180 or 0)
+					return math.deg(math.atan(endY - startY, endX - startX)) + (KmStigerMotVenstre and 180 or 0)
 				end
 			end
 		</Formula>
@@ -313,7 +313,7 @@
 					startY = geoCoord.Y + SymbolOffset.Y
 					endX = closest2.geoCoord.X + closest2.SymbolOffset.X
 					endY = closest2.geoCoord.Y + closest2.SymbolOffset.Y
-					return math.deg(math.atan(endY - startY, endX - startX)) + (MileageIncreasesTowardsLeft and 180 or 0)
+					return math.deg(math.atan(endY - startY, endX - startX)) + (KmStigerMotVenstre and 180 or 0)
 				end
 			end
 		</Formula>
@@ -322,7 +322,7 @@
 	<ObjectType DataType="tOrientedElement" Class="RailwayPlacedObject" Name="JBTEH_MAS KL-mast"
 				Layer="JBTEH_MAS" Color="ByLayer"
 				Group="Kontaktledning/Master"
-				AttMirrorX="{% if MileageIncreasesTowardsLeft %}true{% else %}false{% endif %}"
+				AttMirrorX="{% if KmStigerMotVenstre %}true{% else %}false{% endif %}"
 				AttMirrorY="{% if RightSided %}true{% else %}false{% endif %}"
 				>
 				<!-- Note: AttMirrorX is in use because the span length shall be shown on the hi-mileage side also if M.i.t.l. -->
@@ -763,42 +763,42 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="GMB-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GMBMAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="H-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GITTERMAST-H-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="B-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GITTERMAST-B-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Betongmast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-BETONGMAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Tremast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-TREMAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<SymbolDefinition AllowSymbolMove="true" DefaultBlockName="NO-BN-2D-JBTEH_MAS-BJELKEMAST-{{SymbolMode}}" >

--- a/NO-BN/DNA/_SRC/NO-BN-OcsMasts.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsMasts.xml
@@ -275,7 +275,7 @@
 					startY = geoCoord.Y + SymbolOffset.Y
 					endX = closest.geoCoord.X + closest.SymbolOffset.X
 					endY = closest.geoCoord.Y + closest.SymbolOffset.Y
-					return math.deg(math.atan(endY - startY, endX - startX)) + (KmStigerMotVenstre and 180 or 0)
+					return math.deg(math.atan(endY - startY, endX - startX)) + (MileageIncreasesTowardsLeft and 180 or 0)
 				end
 			end
 		</Formula>
@@ -313,7 +313,7 @@
 					startY = geoCoord.Y + SymbolOffset.Y
 					endX = closest2.geoCoord.X + closest2.SymbolOffset.X
 					endY = closest2.geoCoord.Y + closest2.SymbolOffset.Y
-					return math.deg(math.atan(endY - startY, endX - startX)) + (KmStigerMotVenstre and 180 or 0)
+					return math.deg(math.atan(endY - startY, endX - startX)) + (MileageIncreasesTowardsLeft and 180 or 0)
 				end
 			end
 		</Formula>
@@ -322,7 +322,7 @@
 	<ObjectType DataType="tOrientedElement" Class="RailwayPlacedObject" Name="JBTEH_MAS KL-mast"
 				Layer="JBTEH_MAS" Color="ByLayer"
 				Group="Kontaktledning/Master"
-				AttMirrorX="{% if KmStigerMotVenstre %}true{% else %}false{% endif %}"
+				AttMirrorX="{% if MileageIncreasesTowardsLeft %}true{% else %}false{% endif %}"
 				AttMirrorY="{% if RightSided %}true{% else %}false{% endif %}"
 				>
 				<!-- Note: AttMirrorX is in use because the span length shall be shown on the hi-mileage side also if M.i.t.l. -->
@@ -763,42 +763,42 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="GMB-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GMBMAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="H-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GITTERMAST-H-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="B-mast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-GITTERMAST-B-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Betongmast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-BETONGMAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="Tremast" DisplayBlockName="NO-BN-2D-JBTEH_MAS-TREMAST-{{SymbolMode}}" 
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4" SubGroup="Ordinære master" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" EnableDirectionSetting="false" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<SymbolDefinition AllowSymbolMove="true" DefaultBlockName="NO-BN-2D-JBTEH_MAS-BJELKEMAST-{{SymbolMode}}" >

--- a/NO-BN/DNA/_SRC/NO-BN-OcsVariousObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsVariousObjects.xml
@@ -429,7 +429,7 @@
 							return "Cannot connect to targert alignment of type '"..Alignmnent.RcType.."'.",_warning
 						end
 						--2021-08-23 CLFEY: Leave the text as-is, emphasize showing what is own / what is target:
-						--if MileageIncreasesTowardsLeft then
+						--if KmStigerMotVenstre then
 						--	first,second = second,first 
 						--end
 						return "["..first.Code.."] ==> ["..second.Code.."]"

--- a/NO-BN/DNA/_SRC/NO-BN-OcsVariousObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-OcsVariousObjects.xml
@@ -429,7 +429,7 @@
 							return "Cannot connect to targert alignment of type '"..Alignmnent.RcType.."'.",_warning
 						end
 						--2021-08-23 CLFEY: Leave the text as-is, emphasize showing what is own / what is target:
-						--if KmStigerMotVenstre then
+						--if MileageIncreasesTowardsLeft then
 						--	first,second = second,first 
 						--end
 						return "["..first.Code.."] ==> ["..second.Code.."]"

--- a/NO-BN/DNA/_SRC/NO-BN-SignalingObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-SignalingObjects.xml
@@ -1104,12 +1104,12 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="DelimiterType" Value="JBTSA_TEL Akselteller sensor" />
 		</InsertPointObject>
 		
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<SymbolAttribute Tag="X" >
 				<Value>{{code}}</Value>
 			</SymbolAttribute>
@@ -1218,7 +1218,7 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 							end
 						end
 					end
-					if MileageIncreasesTowardsLeft then first,second = second,first end
+					if KmStigerMotVenstre then first,second = second,first end
 					if first == "-" and second == "-" then
 						return first.."/"..second, _info("UNFINISHED - Create axle counter Section object(s) to obtain the section numbers 'a/b' for the sensor.")
 					else
@@ -1300,7 +1300,7 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="0.75" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_TEL-AKSELTELLER-SENSOR-{{SymbolMode}}" AllowSymbolMove="true" >
@@ -1535,13 +1535,13 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 		<InsertPointObject VariantName="Sporfelt" DisplayBlockName="NO-BN-2D-JBTRC_SEKSJON-INNSETTING-SYMBOL-Schematic"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="SymbolFrame" Value="Symbolramme-R2.75" />
 			<SetValue Key="DelimiterType" Value="JBTKO_SKJ Skinneskjøt" />
 		</InsertPointObject>
 	
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<SymbolAttribute Tag="X" >
 				<Value>{{code}}</Value>
 			</SymbolAttribute>
@@ -1644,7 +1644,7 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="0" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" RotateIfRightSideOfAlignment="false" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="true" Layer="JBTKO_SKJ" >

--- a/NO-BN/DNA/_SRC/NO-BN-SignalingObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-SignalingObjects.xml
@@ -1104,12 +1104,12 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="DelimiterType" Value="JBTSA_TEL Akselteller sensor" />
 		</InsertPointObject>
 		
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<SymbolAttribute Tag="X" >
 				<Value>{{code}}</Value>
 			</SymbolAttribute>
@@ -1218,7 +1218,7 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 							end
 						end
 					end
-					if KmStigerMotVenstre then first,second = second,first end
+					if MileageIncreasesTowardsLeft then first,second = second,first end
 					if first == "-" and second == "-" then
 						return first.."/"..second, _info("UNFINISHED - Create axle counter Section object(s) to obtain the section numbers 'a/b' for the sensor.")
 					else
@@ -1300,7 +1300,7 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="0.75" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" RotateIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTSA_TEL-AKSELTELLER-SENSOR-{{SymbolMode}}" AllowSymbolMove="true" >
@@ -1535,13 +1535,13 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 		<InsertPointObject VariantName="Sporfelt" DisplayBlockName="NO-BN-2D-JBTRC_SEKSJON-INNSETTING-SYMBOL-Schematic"
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="SymbolFrame" Value="Symbolramme-R2.75" />
 			<SetValue Key="DelimiterType" Value="JBTKO_SKJ Skinneskjøt" />
 		</InsertPointObject>
 	
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" >
-			<Rotation AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<SymbolAttribute Tag="X" >
 				<Value>{{code}}</Value>
 			</SymbolAttribute>
@@ -1644,7 +1644,7 @@ TODO: Ref Issue #5708 fra 2019-07-09: Add element: Description="https://trv.bane
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="0" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance AddAngle="0" RotateIfRightSideOfAlignment="false" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<SymbolDefinition DefaultBlockName="" AllowSymbolMove="true" Layer="JBTKO_SKJ" >

--- a/NO-BN/DNA/_SRC/NO-BN-Signals.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Signals.xml
@@ -298,7 +298,7 @@ end
 		
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -321,7 +321,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="Yokemounted" Value="False" />
+				<SetValue Key="PortalMounted" Value="False" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, sidestilt med dverg" >
 				<SetValue Key="type" Value="main" />
@@ -329,7 +329,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="Yokemounted" Value="False" />
+				<SetValue Key="PortalMounted" Value="False" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, sidestilt med lav dverg" >
 				<SetValue Key="type" Value="main" />
@@ -337,7 +337,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="Yokemounted" Value="False" />
+				<SetValue Key="PortalMounted" Value="False" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, over sporet" >
 				<SetValue Key="type" Value="main" />
@@ -345,7 +345,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="Yokemounted" Value="True" />
+				<SetValue Key="PortalMounted" Value="True" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, over sporet med dverg" >
 				<SetValue Key="type" Value="main" />
@@ -353,7 +353,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="Yokemounted" Value="True" />
+				<SetValue Key="PortalMounted" Value="True" />
 			</Variant>
 			<Variant Name="ERTMS dverg" >
 				<SetValue Key="type" Value="shunting" />
@@ -361,7 +361,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="Yokemounted" Value="False" />
+				<SetValue Key="PortalMounted" Value="False" />
 			</Variant>
 		</Variants>
 
@@ -381,16 +381,16 @@ end
 				function _JBTSA_SIG_ertms_Offset3dZ(_position)
 					
 					if Variant == "ERTMS E35 Stoppskilt, sidestilt med dverg" then
-						return Yokemounted and -3.2 or 1.9
+						return PortalMounted and -3.2 or 1.9
 					
 					elseif Variant == "ERTMS E35 Stoppskilt, sidestilt med lav dverg" then
-						return Yokemounted and -3.0 or 0.2
+						return PortalMounted and -3.0 or 0.2
 						
 					elseif Variant == "ERTMS dverg" then
-						return Yokemounted and -2.6 or 1.3
+						return PortalMounted and -2.6 or 1.3
 
 					else
-						return Yokemounted and -3.0 or 3.3
+						return PortalMounted and -3.0 or 3.3
 					end
 				end
 			</Formula>
@@ -483,7 +483,7 @@ end
 				{% elsif Variant contains 'over' %}ERTMS-E35-OVER
 				{% endif %}
 				{% if Variant contains 'dverg' %}DS{% endif %}
-				{% if Yokemounted %}AAK{% endif %}
+				{% if PortalMounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -538,11 +538,11 @@ function NOBN_sig_chkSafetyDistanceFromSignalToOcsMast()
 
 	--Check if this test can be omitted (a low signal):
 	local omit = true
-	if Yokemounted then 
+	if PortalMounted then 
 		omit = false
 
 	elseif RcType == "JBTSA_ERT ERTMS-signal" then
-		if Yokemounted then
+		if PortalMounted then
 			return "WARNING - Check manually that no OCS yoke is within safety distance from markerboard in yoke.",_warning
 		else
 			return "OK - Markerboard on the ground - Safety distance to OCS mast not relevant.",_ok
@@ -598,7 +598,7 @@ end
 				side = side and side:lower() or "(no arg)"				
 				if side ~= "left" and side ~= "right" then return "*** ERROR Function should be called with argument 'right' or 'left' ["..side.."]." end
 				if Alignment == nil then return "UNFINISHED - Signal must first be assigned to an alignment to deduce its own direction." end
-				if (DwarfSignal == "Ja" and MainSignal == "-" and Yokemounted) then return "WARNING - Shunting signal mounted in yoke. Please do manual check.",_warning end
+				if (DwarfSignal == "Ja" and MainSignal == "-" and PortalMounted) then return "WARNING - Shunting signal mounted in yoke. Please do manual check.",_warning end
 --2021-01-12 CLFEY: No warning just if high above but outside lateral problem distance.
 --if (RelativeElevation &gt; 0.3) then return "WARNING - Signal mounted outside normal elevations. Please do manual check.",_warning end
 				tracks = getClosestAlignments("JBTKO_SPO Spor"):filter(function (x) return (side:upper() == "RIGHT" and 1 or -1) * getAlignmentInfo(x.id).DistanceToAlignment &lt; 0 end)
@@ -674,7 +674,7 @@ end
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_SYMBOLFRAME" />
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
@@ -837,7 +837,7 @@ end
 					if (DepartureSignal ~= "-") then t = t.."-AVS" end --Avgangssignal
 					if (BrakeTestSignal ~= "-") then t = t.."-BPS" end --Bremseprøvesignal
 					if Sunscreen == "-" then t = t.."-UTEN-SKJERM" end
-					if Yokemounted then t = t.."-ÅK" end
+					if PortalMounted then t = t.."-ÅK" end
 					if KneeTowardsTrack then if KneeTowardsTrack ~= "-" then t = t..(RightSided and "-VKNE" or "-HKNE") end end
 					if t:match("%-NSI63%-DS") and not t:match("ÅK") then t = t.."-2000" end --Add '-2000' pole total length to shunting signal if free-standing shunting signal
 					return t
@@ -1832,7 +1832,7 @@ end
 			{% if OpticalSpeedSignal == 'Ja' %}LHS{% endif %}
 			{% if BrakeTestSignal == 'Ja' %}BPS{% endif %}
 			{% if DepartureSignal == 'Ja' %}AVS{% endif %}
-			{% if Yokemounted %}AAK{% endif %}
+			{% if PortalMounted %}AAK{% endif %}
 			{{SymbolMode}}
 			</BlockNameFormat>
 			
@@ -1876,7 +1876,7 @@ end
 		<AttachTo Category="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -2026,7 +2026,7 @@ end
 					{% endif %}
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if Yokemounted %}AAK{% endif %}
+				{% if PortalMounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -2067,7 +2067,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -2127,7 +2127,7 @@ end
 			<SetValue Key="switchable" Value="true" />
 			<SetValue Key="virtual" Value="false" />
 			<SetValue Key="ruleCode" Value="" />
-			<SetValue Key="Yokemounted" Value="False" />
+			<SetValue Key="PortalMounted" Value="False" />
 		</InsertPointObject>
 		
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-Schematic" AllowSymbolMove="true" >
@@ -2145,7 +2145,7 @@ end
 				{% elsif Variant == 'Frittstående Høyt Skiftesignal med Middelkontroll' %}41-HØYT-SKIFTESIGNAL-MKS
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if Yokemounted %}AAK{% endif %}
+				{% if PortalMounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -2182,7 +2182,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
@@ -2264,7 +2264,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
@@ -2353,7 +2353,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />

--- a/NO-BN/DNA/_SRC/NO-BN-Signals.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-Signals.xml
@@ -298,7 +298,7 @@ end
 		
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -321,7 +321,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="PortalMounted" Value="False" />
+				<SetValue Key="Yokemounted" Value="False" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, sidestilt med dverg" >
 				<SetValue Key="type" Value="main" />
@@ -329,7 +329,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="PortalMounted" Value="False" />
+				<SetValue Key="Yokemounted" Value="False" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, sidestilt med lav dverg" >
 				<SetValue Key="type" Value="main" />
@@ -337,7 +337,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="PortalMounted" Value="False" />
+				<SetValue Key="Yokemounted" Value="False" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, over sporet" >
 				<SetValue Key="type" Value="main" />
@@ -345,7 +345,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="PortalMounted" Value="True" />
+				<SetValue Key="Yokemounted" Value="True" />
 			</Variant>
 			<Variant Name="ERTMS E35 Stoppskilt, over sporet med dverg" >
 				<SetValue Key="type" Value="main" />
@@ -353,7 +353,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="PortalMounted" Value="True" />
+				<SetValue Key="Yokemounted" Value="True" />
 			</Variant>
 			<Variant Name="ERTMS dverg" >
 				<SetValue Key="type" Value="shunting" />
@@ -361,7 +361,7 @@ end
 				<SetValue Key="switchable" Value="false" />
 				<SetValue Key="virtual" Value="false" />
 				<SetValue Key="ruleCode" Value="" />
-				<SetValue Key="PortalMounted" Value="False" />
+				<SetValue Key="Yokemounted" Value="False" />
 			</Variant>
 		</Variants>
 
@@ -381,16 +381,16 @@ end
 				function _JBTSA_SIG_ertms_Offset3dZ(_position)
 					
 					if Variant == "ERTMS E35 Stoppskilt, sidestilt med dverg" then
-						return PortalMounted and -3.2 or 1.9
+						return Yokemounted and -3.2 or 1.9
 					
 					elseif Variant == "ERTMS E35 Stoppskilt, sidestilt med lav dverg" then
-						return PortalMounted and -3.0 or 0.2
+						return Yokemounted and -3.0 or 0.2
 						
 					elseif Variant == "ERTMS dverg" then
-						return PortalMounted and -2.6 or 1.3
+						return Yokemounted and -2.6 or 1.3
 
 					else
-						return PortalMounted and -3.0 or 3.3
+						return Yokemounted and -3.0 or 3.3
 					end
 				end
 			</Formula>
@@ -483,7 +483,7 @@ end
 				{% elsif Variant contains 'over' %}ERTMS-E35-OVER
 				{% endif %}
 				{% if Variant contains 'dverg' %}DS{% endif %}
-				{% if PortalMounted %}AAK{% endif %}
+				{% if Yokemounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -538,11 +538,11 @@ function NOBN_sig_chkSafetyDistanceFromSignalToOcsMast()
 
 	--Check if this test can be omitted (a low signal):
 	local omit = true
-	if PortalMounted then 
+	if Yokemounted then 
 		omit = false
 
 	elseif RcType == "JBTSA_ERT ERTMS-signal" then
-		if PortalMounted then
+		if Yokemounted then
 			return "WARNING - Check manually that no OCS yoke is within safety distance from markerboard in yoke.",_warning
 		else
 			return "OK - Markerboard on the ground - Safety distance to OCS mast not relevant.",_ok
@@ -598,7 +598,7 @@ end
 				side = side and side:lower() or "(no arg)"				
 				if side ~= "left" and side ~= "right" then return "*** ERROR Function should be called with argument 'right' or 'left' ["..side.."]." end
 				if Alignment == nil then return "UNFINISHED - Signal must first be assigned to an alignment to deduce its own direction." end
-				if (DwarfSignal == "Ja" and MainSignal == "-" and PortalMounted) then return "WARNING - Shunting signal mounted in yoke. Please do manual check.",_warning end
+				if (DwarfSignal == "Ja" and MainSignal == "-" and Yokemounted) then return "WARNING - Shunting signal mounted in yoke. Please do manual check.",_warning end
 --2021-01-12 CLFEY: No warning just if high above but outside lateral problem distance.
 --if (RelativeElevation &gt; 0.3) then return "WARNING - Signal mounted outside normal elevations. Please do manual check.",_warning end
 				tracks = getClosestAlignments("JBTKO_SPO Spor"):filter(function (x) return (side:upper() == "RIGHT" and 1 or -1) * getAlignmentInfo(x.id).DistanceToAlignment &lt; 0 end)
@@ -674,7 +674,7 @@ end
 		<!-- <xpp:expand select="NOBN_xxx_DEPRECATED_MACRO___TO_BE_REMOVED" /> -->
 		<xpp:expand select="NOBN_com_SYMBOLFRAME" />
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
@@ -837,7 +837,7 @@ end
 					if (DepartureSignal ~= "-") then t = t.."-AVS" end --Avgangssignal
 					if (BrakeTestSignal ~= "-") then t = t.."-BPS" end --Bremseprøvesignal
 					if Sunscreen == "-" then t = t.."-UTEN-SKJERM" end
-					if PortalMounted then t = t.."-ÅK" end
+					if Yokemounted then t = t.."-ÅK" end
 					if KneeTowardsTrack then if KneeTowardsTrack ~= "-" then t = t..(RightSided and "-VKNE" or "-HKNE") end end
 					if t:match("%-NSI63%-DS") and not t:match("ÅK") then t = t.."-2000" end --Add '-2000' pole total length to shunting signal if free-standing shunting signal
 					return t
@@ -1832,7 +1832,7 @@ end
 			{% if OpticalSpeedSignal == 'Ja' %}LHS{% endif %}
 			{% if BrakeTestSignal == 'Ja' %}BPS{% endif %}
 			{% if DepartureSignal == 'Ja' %}AVS{% endif %}
-			{% if PortalMounted %}AAK{% endif %}
+			{% if Yokemounted %}AAK{% endif %}
 			{{SymbolMode}}
 			</BlockNameFormat>
 			
@@ -1876,7 +1876,7 @@ end
 		<AttachTo Category="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -2026,7 +2026,7 @@ end
 					{% endif %}
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if PortalMounted %}AAK{% endif %}
+				{% if Yokemounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -2067,7 +2067,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
 		<xpp:expand select="NOBN_com_CHK_NUMBER_OF_OCP_AREAS" />
@@ -2127,7 +2127,7 @@ end
 			<SetValue Key="switchable" Value="true" />
 			<SetValue Key="virtual" Value="false" />
 			<SetValue Key="ruleCode" Value="" />
-			<SetValue Key="PortalMounted" Value="False" />
+			<SetValue Key="Yokemounted" Value="False" />
 		</InsertPointObject>
 		
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTRC_THUMBNAIL-USPESIFISERT-Schematic" AllowSymbolMove="true" >
@@ -2145,7 +2145,7 @@ end
 				{% elsif Variant == 'Frittstående Høyt Skiftesignal med Middelkontroll' %}41-HØYT-SKIFTESIGNAL-MKS
 				{% else %}BAD_Variant
 				{% endif %}
-				{% if PortalMounted %}AAK{% endif %}
+				{% if Yokemounted %}AAK{% endif %}
 				{{SymbolMode}}
 			</BlockNameFormat>
 		</SymbolDefinition>
@@ -2182,7 +2182,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
@@ -2264,7 +2264,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />
@@ -2353,7 +2353,7 @@ end
 		<AttachmentCategory Name="signal" />
 
 		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET_VAR" />
-		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" />
+		<xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" />
 		<xpp:expand select="NOBN_sig_STD_CUSTOMATTRIBUTES___SPREADING_LENS" />
 		<xpp:expand select="NOBN_com_STD_TEXTATTRIBUTES___HORIZONTAL_AND_CLOSE___SIG" />
 		<xpp:expand select="NOBN_com_DISCIPLINE___SIG" />

--- a/NO-BN/DNA/_SRC/NO-BN-StandardProperties.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-StandardProperties.xml
@@ -186,26 +186,36 @@
 	<PropertyOverride Name="lang"														Category="Basic" />
 
 <PropertyCategory Name="General" DisplayName="Generelt"								Collapsed="false" />	<!-- Intrinsic (Note: Intrinsic cat. 'General' will be deprecated) -->
-	<PropertyOverride Name="Variant"													Category="General" />
-	<PropertyOverride Name="code" DisplayName="Kode"									Category="General" /> 
-	<PropertyOverride Name="name" DisplayName="Objektnavn"								Category="General" /> 
-	<PropertyOverride Name="Discipline" DisplayName="Fag"								Category="General" /> 
-	<PropertyOverride Name="Stage" DisplayName="Fasekode XXxx-YYyy"						Category="General" /> 
+	<PropertyOverride Name="Variant" DisplayName="Variant"								Category="General" />
+	<PropertyOverride Name="ProxySymbolBlockName" DisplayName="Proxy blokknavn for 2D-symbolet"	Category="General" />
+	<PropertyOverride Name="ProxySymbolAttDefText" DisplayName="Proxy tekst i 2D-symbolet"	Category="General" />
+	<PropertyOverride Name="Seq" DisplayName="Sekvensnummer"							Category="General" />
+	<PropertyOverride Name="code" DisplayName="Kode"									Category="General" />
+	<PropertyOverride Name="name" DisplayName="Objektnavn"								Category="General" />
+	<PropertyOverride Name="Discipline" DisplayName="Fag"								Category="General" />
+	<PropertyOverride Name="Stage" DisplayName="Fasekode XXxx-YYyy"						Category="General" />
+	<PropertyOverride Name="Tag" DisplayName="Banedata objekt-ID"						Category="General" />
+	<PropertyOverride Name="description" DisplayName="Beskrivelse"						Category="General" />
 
 <PropertyCategory Name="Aligned object" DisplayName="Plassering langs linje"		Collapsed="false" />	<!-- Intrinsic (Linear Placement) -->
-	<PropertyOverride Name="Alignment" DisplayName="Egen linje"							Category="Aligned object" /> 
-	<PropertyOverride Name="Mileage" DisplayName="Profil egen linje (PEL)"				Category="Aligned object" /> 
-	<PropertyOverride Name="ReferenceAlignment" DisplayName="Referanselinje"			Category="Aligned object" /> 
-	<PropertyOverride Name="ReferenceMileage" DisplayName="Km"							Category="Aligned object" /> 
-	<PropertyOverride Name="SideOfAlignment"  DisplayName="Side av egen linje"			Category="Aligned object" /> 
-	<PropertyOverride Name="dir" DisplayName="Retning"									Category="Aligned object" /> 
-	<PropertyOverride Name="pos" DisplayName="Plassering fra start i egen linje"		Category="Aligned object" /> 
-	<PropertyOverride Name="DistanceToAlignment" DisplayName="Sideavsett fra egen linje"	Category="Aligned object" /> 
-	<PropertyOverride Name="RelativeElevation" DisplayName="Høyde over egen linje"		Category="Aligned object" /> 
-	<PropertyOverride Name="TargetAlignment" DisplayName="Tilstøtende linje"			Category="Aligned object" />
+	<PropertyOverride Name="Alignment" DisplayName="Linje"								Category="Aligned object" />
+	<PropertyOverride Name="TargetAlignment" DisplayName="Avvikende / tilstøtende linje"	Category="Aligned object" />
+	<PropertyOverride Name="ReferenceAlignment" DisplayName="Referanselinje"			Category="Aligned object" />
+	<PropertyOverride Name="SideOfAlignment" DisplayName="Side av egen linje" Suppressed="true"	Category="Aligned object" />
+	<PropertyOverride Name="dir" DisplayName="Retning"									Category="Aligned object" />
+	<PropertyOverride Name="DistanceAlong" DisplayName="Avstand fra linjestart [m]"		Category="Aligned object" />
+	<PropertyOverride Name="Mileage" DisplayName="Profil langs linje [m]"				Category="Aligned object" />
+	<PropertyOverride Name="ReferenceMileage" DisplayName="Km iht. referanselinje [m]"	Category="Aligned object" />
+	<PropertyOverride Name="LateralOffset" DisplayName="Sideavsett fra linje [m]"		Category="Aligned object" />
+	<PropertyOverride Name="LongitudinalOffset" DisplayName="Offset langs line [m]"		Category="Aligned object" />
+	<PropertyOverride Name="VerticalOffset" DisplayName="Høyde over linje [m]"			Category="Aligned object" />
+	<PropertyOverride Name="DistanceToAlignment" DisplayName="Avstand til linje [m]"	Category="Aligned object" />
+	<PropertyOverride Name="AngularOffset" DisplayName="Vinkel-tillegg"					Category="Aligned object" />
 
 <PropertyCategory Name="Custom properties" DisplayName="Spesifikke egenskaper"		Collapsed="false" />	<!-- Intrinsic -->
-																			
+
+<PropertyCategory Name="Text Attributes" DisplayName="Tekstattributter"				Collapsed="true"  />	<!-- Intrinsic -->
+
 <PropertyCategory Name="Model check" DisplayName="Modellsjekk"						Collapsed="false" />	<!-- Custom -->
 
 <PropertyCategory Name="Presentation" DisplayName="2D presentasjon"					Collapsed="true"  />	<!-- Intrinsic -->
@@ -213,7 +223,7 @@
 	<PropertyOverride Name="DrawTail" DisplayName="Tegne halen"							Category="Presentation" />
 	<PropertyOverride Name="DrawTailExtension" DisplayName="Forlenge halen"				Category="Presentation" />
 	<PropertyOverride Name="SymbolFrame" DisplayName="Symbolramme"						Category="Presentation" />
-	<PropertyOverride Name="KmStigerMotVenstre"											Category="Presentation" />
+	<PropertyOverride Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre"	Category="Presentation" />
 
 <PropertyCategory Name="CAD" DisplayName="CAD"										Collapsed="true"  />	<!-- Intrinsic -->
 	<PropertyOverride Name="Color" DisplayName="Farge"									Category="CAD" />
@@ -223,10 +233,12 @@
 	<PropertyOverride Name="GlobalWidth" DisplayName="Global linjebredde"				Category="CAD" />
 
 <PropertyCategory Name="3D" DisplayName="3D geometri"								Collapsed="true"  />	<!-- Intrinsic -->
-	<PropertyOverride Name="geoCoord" DisplayName="Koordinater"							Category="3D" />	<!-- Intrinsic property which didn't have a category -->		
+	<PropertyOverride Name="geoCoord" DisplayName="Innsettingspunkt i WCS (øst, nord, h.o.h.)"	Category="3D" />
+	<PropertyOverride Name="Layer3D" DisplayName="3D-geometri lag"						Category="3D" />
+
+<PropertyCategory Name="2D Projection" DisplayName="2D projeksjon"					Collapsed="true"  />	<!-- Intrinsic -->
 
 <PropertyCategory Name="Local variables" DisplayName="Lokale variable"				Collapsed="true" />		<!-- Custom -->
-	<PropertyOverride Name="Seq" DisplayName="Sekvensnummer"							Category="Local variables" />
 	<PropertyOverride Name="Var0"														Category="Local variables" />
 	<PropertyOverride Name="Var1"														Category="Local variables" />
 	<PropertyOverride Name="Var2"														Category="Local variables" />
@@ -249,9 +261,9 @@
 <PropertyCategory Name="Sections" DisplayName="Seksjoner"							Collapsed="true"  />	<!-- Intrinsic -->
 
 <PropertyCategory Name="Formulas" DisplayName="Formler"								Collapsed="true"  />	<!-- Intrinsic -->
-	<PropertyOverride Name="LuaExpressions" DisplayName="Lua uttrykk"					Category="Formulas" />
+	<PropertyOverride Name="LuaExpressions" DisplayName="Lua formler"					Category="Formulas" />
 		
-<PropertyCategory Name="Misc" DisplayName="railML og annet"							Collapsed="true"  />   	<!-- Intrinsic -->
+<PropertyCategory Name="Misc"													Collapsed="true"  />   	<!-- Intrinsic -->
 	<PropertyOverride Name="model" DisplayName="railML modell"		 					Category="Misc" />
 	<PropertyOverride Name="kind" DisplayName="railML avart"		 					Category="Misc" />
 	<PropertyOverride Name="derailSide" DisplayName="Avsporingsside" 					Category="Misc" />
@@ -268,8 +280,8 @@
 	<!-- NB: "TargetAlignment" has been moved to category "Aligned object" (= linear positioning) -->
 	<PropertyOverride Name="SwitchGeometry" DisplayName="Sporvekselgeometri"			Category="Connections" />
 	<PropertyOverride Name="ConnectionCourse" DisplayName="Forbindelsesretning"			Category="Connections" />
-	<PropertyOverride Name="ContinuingWithBegin" DisplayName="Påfølgende spor starter her"	Category="Connections" />
-	<PropertyOverride Name="ExtendingFromEnd" DisplayName="Foregående spor ender her"	Category="Connections" />
+	<PropertyOverride Name="ContinuingWithBegin" DisplayName="Påfølgende linje starter her"	Category="Connections" />
+	<PropertyOverride Name="ExtendingFromEnd" DisplayName="Foregående linje ender her"	Category="Connections" />
 
 
 <PropertyCategory Name="Pset Bane NOR"												Collapsed="true"  />	<!-- Custom -->
@@ -391,9 +403,9 @@
 		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___MILEAGE_INCREASES_TOWARDS_LEFT" /> -->
 <xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___MILEAGE_INCREASES_TOWARDS_LEFT" >
 	<xpp:bloc>
-		<CustomAttribute DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" InvertOnAlignmentReverse="true" DefaultValue="False" 
+		<CustomAttribute DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" InvertOnAlignmentReverse="true" DefaultValue="False"
 			Category="Presentation"
-			Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." 
+			Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc."
 		 /> 
 	</xpp:bloc>
 </xpp:define>
@@ -403,7 +415,7 @@
 		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET" /> -->
 <xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET" >
 	<xpp:bloc>
-		<CustomAttribute DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" DefaultValue="0.0" Category="3D"
+		<CustomAttribute DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" DefaultValue="0.0" Category="Aligned object"
 			Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." />
 	</xpp:bloc>
 </xpp:define>
@@ -429,11 +441,11 @@
 
 
 
-		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" /> -->
-<xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" >
+		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" /> -->
+<xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" >
 	<xpp:bloc>
-		<CustomAttribute DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" DefaultValue="False" Category="Custom properties"
-			Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." />
+		<CustomAttribute DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" DefaultValue="False" Category="Custom properties"
+			Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." />
 	</xpp:bloc>
 </xpp:define>
 
@@ -598,9 +610,9 @@
 	<xpp:bloc>
 		<LuaExpression Name="RelativeElevation" >
 			<Formula>
-				if Yokemounted then
-					--Object has  the Yokemounted custom attribute:
-					return Yokemounted and 8.0 or 0
+				if PortalMounted then
+					--Object has  the PortalMounted custom attribute:
+					return PortalMounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -624,7 +636,7 @@
 	<!-- <xpp:expand select="NOBN_com_STD_LUAEXPRESSIONS___WAYSIDE_SIGNAL_OBJECT" /> -->
 <xpp:define name="NOBN_com_STD_LUAEXPRESSIONS___WAYSIDE_SIGNAL_OBJECT" >
 	<xpp:bloc>
-		<LuaExpression Name="RelativeElevation" ><Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula></LuaExpression>
+		<LuaExpression Name="RelativeElevation" ><Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula></LuaExpression>
 		<LuaExpression Name="Rotation3D.Z" ><Formula>NOBN_trk_getYawFromDir()</Formula></LuaExpression>
 		<LuaExpression Name="name" ><Formula>NOBN_sig_getSignalFullName()</Formula></LuaExpression>
 		<LuaExpression Name="ObjectInfo" ><Formula>NOBN_sig_getSignalPartNames()</Formula></LuaExpression>

--- a/NO-BN/DNA/_SRC/NO-BN-StandardProperties.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-StandardProperties.xml
@@ -186,36 +186,26 @@
 	<PropertyOverride Name="lang"														Category="Basic" />
 
 <PropertyCategory Name="General" DisplayName="Generelt"								Collapsed="false" />	<!-- Intrinsic (Note: Intrinsic cat. 'General' will be deprecated) -->
-	<PropertyOverride Name="Variant" DisplayName="Variant"								Category="General" />
-	<PropertyOverride Name="ProxySymbolBlockName" DisplayName="Proxy blokknavn for 2D-symbolet"	Category="General" />
-	<PropertyOverride Name="ProxySymbolAttDefText" DisplayName="Proxy tekst i 2D-symbolet"	Category="General" />
-	<PropertyOverride Name="Seq" DisplayName="Sekvensnummer"							Category="General" />
-	<PropertyOverride Name="code" DisplayName="Kode"									Category="General" />
-	<PropertyOverride Name="name" DisplayName="Objektnavn"								Category="General" />
-	<PropertyOverride Name="Discipline" DisplayName="Fag"								Category="General" />
-	<PropertyOverride Name="Stage" DisplayName="Fasekode XXxx-YYyy"						Category="General" />
-	<PropertyOverride Name="Tag" DisplayName="Banedata objekt-ID"						Category="General" />
-	<PropertyOverride Name="description" DisplayName="Beskrivelse"						Category="General" />
+	<PropertyOverride Name="Variant"													Category="General" />
+	<PropertyOverride Name="code" DisplayName="Kode"									Category="General" /> 
+	<PropertyOverride Name="name" DisplayName="Objektnavn"								Category="General" /> 
+	<PropertyOverride Name="Discipline" DisplayName="Fag"								Category="General" /> 
+	<PropertyOverride Name="Stage" DisplayName="Fasekode XXxx-YYyy"						Category="General" /> 
 
 <PropertyCategory Name="Aligned object" DisplayName="Plassering langs linje"		Collapsed="false" />	<!-- Intrinsic (Linear Placement) -->
-	<PropertyOverride Name="Alignment" DisplayName="Linje"								Category="Aligned object" />
-	<PropertyOverride Name="TargetAlignment" DisplayName="Avvikende / tilstøtende linje"	Category="Aligned object" />
-	<PropertyOverride Name="ReferenceAlignment" DisplayName="Referanselinje"			Category="Aligned object" />
-	<PropertyOverride Name="SideOfAlignment" DisplayName="Side av egen linje" Suppressed="true"	Category="Aligned object" />
-	<PropertyOverride Name="dir" DisplayName="Retning"									Category="Aligned object" />
-	<PropertyOverride Name="DistanceAlong" DisplayName="Avstand fra linjestart [m]"		Category="Aligned object" />
-	<PropertyOverride Name="Mileage" DisplayName="Profil langs linje [m]"				Category="Aligned object" />
-	<PropertyOverride Name="ReferenceMileage" DisplayName="Km iht. referanselinje [m]"	Category="Aligned object" />
-	<PropertyOverride Name="LateralOffset" DisplayName="Sideavsett fra linje [m]"		Category="Aligned object" />
-	<PropertyOverride Name="LongitudinalOffset" DisplayName="Offset langs line [m]"		Category="Aligned object" />
-	<PropertyOverride Name="VerticalOffset" DisplayName="Høyde over linje [m]"			Category="Aligned object" />
-	<PropertyOverride Name="DistanceToAlignment" DisplayName="Avstand til linje [m]"	Category="Aligned object" />
-	<PropertyOverride Name="AngularOffset" DisplayName="Vinkel-tillegg"					Category="Aligned object" />
+	<PropertyOverride Name="Alignment" DisplayName="Egen linje"							Category="Aligned object" /> 
+	<PropertyOverride Name="Mileage" DisplayName="Profil egen linje (PEL)"				Category="Aligned object" /> 
+	<PropertyOverride Name="ReferenceAlignment" DisplayName="Referanselinje"			Category="Aligned object" /> 
+	<PropertyOverride Name="ReferenceMileage" DisplayName="Km"							Category="Aligned object" /> 
+	<PropertyOverride Name="SideOfAlignment"  DisplayName="Side av egen linje"			Category="Aligned object" /> 
+	<PropertyOverride Name="dir" DisplayName="Retning"									Category="Aligned object" /> 
+	<PropertyOverride Name="pos" DisplayName="Plassering fra start i egen linje"		Category="Aligned object" /> 
+	<PropertyOverride Name="DistanceToAlignment" DisplayName="Sideavsett fra egen linje"	Category="Aligned object" /> 
+	<PropertyOverride Name="RelativeElevation" DisplayName="Høyde over egen linje"		Category="Aligned object" /> 
+	<PropertyOverride Name="TargetAlignment" DisplayName="Tilstøtende linje"			Category="Aligned object" />
 
 <PropertyCategory Name="Custom properties" DisplayName="Spesifikke egenskaper"		Collapsed="false" />	<!-- Intrinsic -->
-
-<PropertyCategory Name="Text Attributes" DisplayName="Tekstattributter"				Collapsed="true"  />	<!-- Intrinsic -->
-
+																			
 <PropertyCategory Name="Model check" DisplayName="Modellsjekk"						Collapsed="false" />	<!-- Custom -->
 
 <PropertyCategory Name="Presentation" DisplayName="2D presentasjon"					Collapsed="true"  />	<!-- Intrinsic -->
@@ -223,7 +213,7 @@
 	<PropertyOverride Name="DrawTail" DisplayName="Tegne halen"							Category="Presentation" />
 	<PropertyOverride Name="DrawTailExtension" DisplayName="Forlenge halen"				Category="Presentation" />
 	<PropertyOverride Name="SymbolFrame" DisplayName="Symbolramme"						Category="Presentation" />
-	<PropertyOverride Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre"	Category="Presentation" />
+	<PropertyOverride Name="KmStigerMotVenstre"											Category="Presentation" />
 
 <PropertyCategory Name="CAD" DisplayName="CAD"										Collapsed="true"  />	<!-- Intrinsic -->
 	<PropertyOverride Name="Color" DisplayName="Farge"									Category="CAD" />
@@ -233,12 +223,10 @@
 	<PropertyOverride Name="GlobalWidth" DisplayName="Global linjebredde"				Category="CAD" />
 
 <PropertyCategory Name="3D" DisplayName="3D geometri"								Collapsed="true"  />	<!-- Intrinsic -->
-	<PropertyOverride Name="geoCoord" DisplayName="Innsettingspunkt i WCS (øst, nord, h.o.h.)"	Category="3D" />
-	<PropertyOverride Name="Layer3D" DisplayName="3D-geometri lag"						Category="3D" />
-
-<PropertyCategory Name="2D Projection" DisplayName="2D projeksjon"					Collapsed="true"  />	<!-- Intrinsic -->
+	<PropertyOverride Name="geoCoord" DisplayName="Koordinater"							Category="3D" />	<!-- Intrinsic property which didn't have a category -->		
 
 <PropertyCategory Name="Local variables" DisplayName="Lokale variable"				Collapsed="true" />		<!-- Custom -->
+	<PropertyOverride Name="Seq" DisplayName="Sekvensnummer"							Category="Local variables" />
 	<PropertyOverride Name="Var0"														Category="Local variables" />
 	<PropertyOverride Name="Var1"														Category="Local variables" />
 	<PropertyOverride Name="Var2"														Category="Local variables" />
@@ -261,9 +249,9 @@
 <PropertyCategory Name="Sections" DisplayName="Seksjoner"							Collapsed="true"  />	<!-- Intrinsic -->
 
 <PropertyCategory Name="Formulas" DisplayName="Formler"								Collapsed="true"  />	<!-- Intrinsic -->
-	<PropertyOverride Name="LuaExpressions" DisplayName="Lua formler"					Category="Formulas" />
+	<PropertyOverride Name="LuaExpressions" DisplayName="Lua uttrykk"					Category="Formulas" />
 		
-<PropertyCategory Name="Misc"													Collapsed="true"  />   	<!-- Intrinsic -->
+<PropertyCategory Name="Misc" DisplayName="railML og annet"							Collapsed="true"  />   	<!-- Intrinsic -->
 	<PropertyOverride Name="model" DisplayName="railML modell"		 					Category="Misc" />
 	<PropertyOverride Name="kind" DisplayName="railML avart"		 					Category="Misc" />
 	<PropertyOverride Name="derailSide" DisplayName="Avsporingsside" 					Category="Misc" />
@@ -280,8 +268,8 @@
 	<!-- NB: "TargetAlignment" has been moved to category "Aligned object" (= linear positioning) -->
 	<PropertyOverride Name="SwitchGeometry" DisplayName="Sporvekselgeometri"			Category="Connections" />
 	<PropertyOverride Name="ConnectionCourse" DisplayName="Forbindelsesretning"			Category="Connections" />
-	<PropertyOverride Name="ContinuingWithBegin" DisplayName="Påfølgende linje starter her"	Category="Connections" />
-	<PropertyOverride Name="ExtendingFromEnd" DisplayName="Foregående linje ender her"	Category="Connections" />
+	<PropertyOverride Name="ContinuingWithBegin" DisplayName="Påfølgende spor starter her"	Category="Connections" />
+	<PropertyOverride Name="ExtendingFromEnd" DisplayName="Foregående spor ender her"	Category="Connections" />
 
 
 <PropertyCategory Name="Pset Bane NOR"												Collapsed="true"  />	<!-- Custom -->
@@ -403,9 +391,9 @@
 		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___MILEAGE_INCREASES_TOWARDS_LEFT" /> -->
 <xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___MILEAGE_INCREASES_TOWARDS_LEFT" >
 	<xpp:bloc>
-		<CustomAttribute DataType="Boolean" Name="MileageIncreasesTowardsLeft" DisplayName="Profilverdi stiger mot venstre" InvertOnAlignmentReverse="true" DefaultValue="False"
+		<CustomAttribute DataType="Boolean" Name="KmStigerMotVenstre" DisplayName="Mileage increases towards left" InvertOnAlignmentReverse="true" DefaultValue="False" 
 			Category="Presentation"
-			Description="The 'MileageIncreasesTowardsLeft' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc."
+			Description="The 'KmStigerMotVenstre' property [boolean] true if and only if the object's own alignment has mileage which increases towards the left in the drawing, with the UCS Y-axis pointing upwards. Usage: Used in DNA for orienting 2D symbols correctly of for adjusting left/right parts of texts etc." 
 		 /> 
 	</xpp:bloc>
 </xpp:define>
@@ -415,7 +403,7 @@
 		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET" /> -->
 <xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___ANGULAROFFSET" >
 	<xpp:bloc>
-		<CustomAttribute DataType="Double" Name="AngularOffset" DisplayName="Vinkel-tillegg" DefaultValue="0.0" Category="Aligned object"
+		<CustomAttribute DataType="Double" Name="AngularOffset" DisplayName="3D Angular offset" DefaultValue="0.0" Category="3D"
 			Description="The 'AngularOffset' custom property [DD] is added to the object's basic 3D orientation. The basic orientation is defined by the current 'dir' property's up/down/none/both/unknown value. If property dir is 'unknown' then the orientation will be 45 degrees as a visual reminder that dir is unknown. For some objects types (e.g. yokes) the 2D symbol orientation will also be affected." />
 	</xpp:bloc>
 </xpp:define>
@@ -441,11 +429,11 @@
 
 
 
-		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" /> -->
-<xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___PORTALMOUNTED" >
+		<!-- <xpp:expand select="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" /> -->
+<xpp:define name="NOBN_com_STD_CUSTOMATTRIBUTES___YOKEMOUNTED" >
 	<xpp:bloc>
-		<CustomAttribute DataType="Boolean" Name="PortalMounted" DisplayName="Portalmontert" DefaultValue="False" Category="Custom properties"
-			Description="The 'PortalMounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a portal (true)." />
+		<CustomAttribute DataType="Boolean" Name="Yokemounted" DisplayName="Åkmontert" DefaultValue="False" Category="Custom properties"
+			Description="The 'Yokemounted' boolean custom property defines whether the object (board, signal etc) has its own mast (default:false) or is suspended from a yoke (true)." />
 	</xpp:bloc>
 </xpp:define>
 
@@ -610,9 +598,9 @@
 	<xpp:bloc>
 		<LuaExpression Name="RelativeElevation" >
 			<Formula>
-				if PortalMounted then
-					--Object has  the PortalMounted custom attribute:
-					return PortalMounted and 8.0 or 0
+				if Yokemounted then
+					--Object has  the Yokemounted custom attribute:
+					return Yokemounted and 8.0 or 0
 				else
 					if Variant:find("Baliseskilt") then return 0.30 --Typically located on platform side facing the track
 					elseif Variant:find("75B") then return 2.75 --On tunnel wall
@@ -636,7 +624,7 @@
 	<!-- <xpp:expand select="NOBN_com_STD_LUAEXPRESSIONS___WAYSIDE_SIGNAL_OBJECT" /> -->
 <xpp:define name="NOBN_com_STD_LUAEXPRESSIONS___WAYSIDE_SIGNAL_OBJECT" >
 	<xpp:bloc>
-		<LuaExpression Name="RelativeElevation" ><Formula>if PortalMounted == nil then return 0 else return PortalMounted and 8.0 or 0 end</Formula></LuaExpression>
+		<LuaExpression Name="RelativeElevation" ><Formula>if Yokemounted == nil then return 0 else return Yokemounted and 8.0 or 0 end</Formula></LuaExpression>
 		<LuaExpression Name="Rotation3D.Z" ><Formula>NOBN_trk_getYawFromDir()</Formula></LuaExpression>
 		<LuaExpression Name="name" ><Formula>NOBN_sig_getSignalFullName()</Formula></LuaExpression>
 		<LuaExpression Name="ObjectInfo" ><Formula>NOBN_sig_getSignalPartNames()</Formula></LuaExpression>

--- a/NO-BN/DNA/_SRC/NO-BN-TrackAndWaysideObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-TrackAndWaysideObjects.xml
@@ -59,24 +59,24 @@
 				return r[0] and r[0].ReferenceMileage or getPropertyValue(ReferenceMileage)
 			</Formula>
 		</LuaExpression>
-		<LuaExpression Name="LabelItem1" ><Formula>NOBN_trk_getSwitchLabelItem1(KmStigerMotVenstre)</Formula></LuaExpression>
-		<LuaExpression Name="LabelItem2" ><Formula>NOBN_trk_getSwitchLabelItem2(KmStigerMotVenstre)</Formula></LuaExpression>
+		<LuaExpression Name="LabelItem1" ><Formula>NOBN_trk_getSwitchLabelItem1(MileageIncreasesTowardsLeft)</Formula></LuaExpression>
+		<LuaExpression Name="LabelItem2" ><Formula>NOBN_trk_getSwitchLabelItem2(MileageIncreasesTowardsLeft)</Formula></LuaExpression>
         <LuaExpression Name="LabelItem3" ><Formula>NOBN_trk_getSwitchLabelItem3()</Formula></LuaExpression>
 
 		<InsertPointObject DisplayName="Sporveksel SS/Mid (km-retn mot høyre)" VariantName="D-1-2-HRB-025-018-SPV" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			</InsertPointObject>
 
 		<InsertPointObject DisplayName="Sporveksel SS/Mid (km-retn mot venstre)" VariantName="D-1-2-HLB-025-018-SPV" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HLB-025-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018" AllowSymbolMove="true" >
-			<Rotation Add180DegreesIfDirIsDown="true" AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
+			<Rotation Add180DegreesIfDirIsDown="true" AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTFE_ETI-ETIKETT
 				{% if Variant == 'D-1-2-HLB-025-018-SPV' %}D-1-2-HLB-025-018
@@ -609,7 +609,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTKO_DIV-KARAKTERISTISK-PUNKT-{{SymbolMode}}" AllowSymbolMove="true" >
@@ -732,7 +732,7 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTKO_DIV-KARAKTERISTISK-PUNKT-{{SymbolMode}}" AllowSymbolMove="true" >
@@ -843,7 +843,7 @@
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
 			<SetValue Key="DelimiterType" Value="JBTKO_HOT Horisontalgeometripunkt" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!-- <SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" > -->
@@ -926,7 +926,7 @@
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
 			<SetValue Key="DelimiterType" Value="JBTKO_VET Vertikalprofilpunkt" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!-- <SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" > -->

--- a/NO-BN/DNA/_SRC/NO-BN-TrackAndWaysideObjects.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-TrackAndWaysideObjects.xml
@@ -59,24 +59,24 @@
 				return r[0] and r[0].ReferenceMileage or getPropertyValue(ReferenceMileage)
 			</Formula>
 		</LuaExpression>
-		<LuaExpression Name="LabelItem1" ><Formula>NOBN_trk_getSwitchLabelItem1(MileageIncreasesTowardsLeft)</Formula></LuaExpression>
-		<LuaExpression Name="LabelItem2" ><Formula>NOBN_trk_getSwitchLabelItem2(MileageIncreasesTowardsLeft)</Formula></LuaExpression>
+		<LuaExpression Name="LabelItem1" ><Formula>NOBN_trk_getSwitchLabelItem1(KmStigerMotVenstre)</Formula></LuaExpression>
+		<LuaExpression Name="LabelItem2" ><Formula>NOBN_trk_getSwitchLabelItem2(KmStigerMotVenstre)</Formula></LuaExpression>
         <LuaExpression Name="LabelItem3" ><Formula>NOBN_trk_getSwitchLabelItem3()</Formula></LuaExpression>
 
 		<InsertPointObject DisplayName="Sporveksel SS/Mid (km-retn mot høyre)" VariantName="D-1-2-HRB-025-018-SPV" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			</InsertPointObject>
 
 		<InsertPointObject DisplayName="Sporveksel SS/Mid (km-retn mot venstre)" VariantName="D-1-2-HLB-025-018-SPV" DisplayBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HLB-025-018-{{SymbolMode}}" >
 			<JigSymbolAppearance EnableDirectionSetting="true" />
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_ETI-ETIKETT-D-1-2-HRB-025-018" AllowSymbolMove="true" >
-			<Rotation Add180DegreesIfDirIsDown="true" AddAngle="{% if MileageIncreasesTowardsLeft %}180{% else %}0{% endif %}" />
+			<Rotation Add180DegreesIfDirIsDown="true" AddAngle="{% if KmStigerMotVenstre %}180{% else %}0{% endif %}" />
 			<BlockNameFormat JoinBy="-" >
 				NO-BN-2D-JBTFE_ETI-ETIKETT
 				{% if Variant == 'D-1-2-HLB-025-018-SPV' %}D-1-2-HLB-025-018
@@ -609,7 +609,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTKO_DIV-KARAKTERISTISK-PUNKT-{{SymbolMode}}" AllowSymbolMove="true" >
@@ -732,7 +732,7 @@
 				DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<SymbolDefinition DefaultBlockName="NO-BN-2D-JBTKO_DIV-KARAKTERISTISK-PUNKT-{{SymbolMode}}" AllowSymbolMove="true" >
@@ -843,7 +843,7 @@
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
 			<SetValue Key="DelimiterType" Value="JBTKO_HOT Horisontalgeometripunkt" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!-- <SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" > -->
@@ -926,7 +926,7 @@
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<OwnAlignmentTargetSpace>vei</OwnAlignmentTargetSpace>
 			<SetValue Key="DelimiterType" Value="JBTKO_VET Vertikalprofilpunkt" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!-- <SymbolDefinition DefaultBlockName="NO-BN-2D-JBTFE_SEK-SEKSJON-{{SymbolMode}}" AllowSymbolMove="true" > -->

--- a/NO-BN/DNA/_SRC/NO-BN-TrackConnections.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-TrackConnections.xml
@@ -146,7 +146,7 @@
 							return _error, "Own alignment and continuing alignment cannot be the same ["..first.Code.."]"
 						end
 						--2021-08-23 CLFEY: Leave the text as-is, emphasize showing what is own / what is target:
-						--if MileageIncreasesTowardsLeft then
+						--if KmStigerMotVenstre then
 						--	first,second = second,first 
 						--end
 						return "["..first.Code.."] ==> ["..second.Code.."]"
@@ -174,7 +174,7 @@
 		<InsertPointObject VariantName="Sporfortsettelse" DisplayBlockName="NO-BN-2D-JBTKO_SPF-FORBINDELSE-FORTSETTELSE-0-0-{{SymbolMode}}" 
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 				
 		<!-- Track and embankment viewpoint's symbol (the other disciplines don't show anything) -->
@@ -260,7 +260,7 @@
 						if first.id == second.id then
 							return "Alignment and intersecting alignment cannot be the same ["..first.Code.."]"
 						end
-						if MileageIncreasesTowardsLeft then
+						if KmStigerMotVenstre then
 							first,second = second,first 
 						end
 						return "["..first.Code.."] -X- ["..second.Code.."]"
@@ -277,7 +277,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!-- Track and embankment viewpoint's symbol (the other disciplines don't show anything) -->
@@ -333,7 +333,7 @@
 				>
 
 		<!-- TODO Note: ObjectTypeAttribute declares a local variable which can be used in Dot Liquid but is not available in Lua (?) - must be documented! -->
-		<!-- NB: The 'MileageIncreasesTowardsLeft' attribute corresponds to your screen view, provided that UCS Y azis points mainly upwards (use acad PLAN or EXPLAN command). -->
+		<!-- NB: The 'KmStigerMotVenstre' attribute corresponds to your screen view, provided that UCS Y azis points mainly upwards (use acad PLAN or EXPLAN command). -->
 		<!-- Note: DotLiquid parsing does not strip whitespace, so to test on quadrant == '3' etc, you must write your DotLiquid this way:  '...%}3{%...' when you return the '3'. -->
 		<!-- Expressions such as AttAddX="{{quadrant}}" will work even if 'quadrant' contains whitespace, because the subsequent use of AttAddX in C# core code will strip off whitespace when extracting the numerical value. -->
 		<ObjectTypeAttribute 
@@ -675,7 +675,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 
@@ -685,14 +685,14 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:9 R190 FX 54E3 (KO-701334)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-09-R190-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<!--54E3 FX-->
@@ -700,21 +700,21 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:12 R500 FX 54E3 (KO-701306)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:14 R760 FX 54E3 (KO-701319)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!--60E1 FX-->
@@ -722,35 +722,35 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:11,66 R500 FX 60E1 (KO-800068)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-11.66-R500-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:12 R500 FX 60E1 (KO-800068)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:14 R760 FX 60E1 (KO-701372)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:15 R760 FX 60E1 (KO-701382)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-15-R760-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>		
 		
 		<!--60E1 BX-->
@@ -758,49 +758,49 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:8.21 R300 BX 60E1 (KO-065306)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-08.21-R300-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:12 R500 BX 60E1 (KO-800090)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:14 R760 BX 60E1 (KO-800108)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:15 R760 BX 60E1 (KO-800164)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-15-R760-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:18.4 R1200 BX 60E1 (KO-800081)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-18.4-R1200-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:26.1 R2500 BX 60E1 (KO-701399)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-26.1-R2500-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<!-- Track and embankment viewpoint's symbol -->
@@ -1369,7 +1369,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1377,7 +1377,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1385,7 +1385,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1393,7 +1393,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1401,7 +1401,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 		
@@ -1409,7 +1409,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1417,7 +1417,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1425,7 +1425,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 

--- a/NO-BN/DNA/_SRC/NO-BN-TrackConnections.xml
+++ b/NO-BN/DNA/_SRC/NO-BN-TrackConnections.xml
@@ -146,7 +146,7 @@
 							return _error, "Own alignment and continuing alignment cannot be the same ["..first.Code.."]"
 						end
 						--2021-08-23 CLFEY: Leave the text as-is, emphasize showing what is own / what is target:
-						--if KmStigerMotVenstre then
+						--if MileageIncreasesTowardsLeft then
 						--	first,second = second,first 
 						--end
 						return "["..first.Code.."] ==> ["..second.Code.."]"
@@ -174,7 +174,7 @@
 		<InsertPointObject VariantName="Sporfortsettelse" DisplayBlockName="NO-BN-2D-JBTKO_SPF-FORBINDELSE-FORTSETTELSE-0-0-{{SymbolMode}}" 
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 				
 		<!-- Track and embankment viewpoint's symbol (the other disciplines don't show anything) -->
@@ -260,7 +260,7 @@
 						if first.id == second.id then
 							return "Alignment and intersecting alignment cannot be the same ["..first.Code.."]"
 						end
-						if KmStigerMotVenstre then
+						if MileageIncreasesTowardsLeft then
 							first,second = second,first 
 						end
 						return "["..first.Code.."] -X- ["..second.Code.."]"
@@ -277,7 +277,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!-- Track and embankment viewpoint's symbol (the other disciplines don't show anything) -->
@@ -333,7 +333,7 @@
 				>
 
 		<!-- TODO Note: ObjectTypeAttribute declares a local variable which can be used in Dot Liquid but is not available in Lua (?) - must be documented! -->
-		<!-- NB: The 'KmStigerMotVenstre' attribute corresponds to your screen view, provided that UCS Y azis points mainly upwards (use acad PLAN or EXPLAN command). -->
+		<!-- NB: The 'MileageIncreasesTowardsLeft' attribute corresponds to your screen view, provided that UCS Y azis points mainly upwards (use acad PLAN or EXPLAN command). -->
 		<!-- Note: DotLiquid parsing does not strip whitespace, so to test on quadrant == '3' etc, you must write your DotLiquid this way:  '...%}3{%...' when you return the '3'. -->
 		<!-- Expressions such as AttAddX="{{quadrant}}" will work even if 'quadrant' contains whitespace, because the subsequent use of AttAddX in C# core code will strip off whitespace when extracting the numerical value. -->
 		<ObjectTypeAttribute 
@@ -675,7 +675,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 
@@ -685,14 +685,14 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:9 R190 FX 54E3 (KO-701334)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-09-R190-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<!--54E3 FX-->
@@ -700,21 +700,21 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:12 R500 FX 54E3 (KO-701306)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:14 R760 FX 54E3 (KO-701319)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-54E3-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<!--60E1 FX-->
@@ -722,35 +722,35 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:11,66 R500 FX 60E1 (KO-800068)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-11.66-R500-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:12 R500 FX 60E1 (KO-800068)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:14 R760 FX 60E1 (KO-701372)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:15 R760 FX 60E1 (KO-701382)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-15-R760-60E1-FX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>		
 		
 		<!--60E1 BX-->
@@ -758,49 +758,49 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 		
 		<InsertPointObject VariantName="1:8.21 R300 BX 60E1 (KO-065306)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-08.21-R300-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:12 R500 BX 60E1 (KO-800090)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-12-R500-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:14 R760 BX 60E1 (KO-800108)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-14-R760-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:15 R760 BX 60E1 (KO-800164)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-15-R760-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:18.4 R1200 BX 60E1 (KO-800081)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-18.4-R1200-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<InsertPointObject VariantName="1:26.1 R2500 BX 60E1 (KO-701399)" DisplayBlockName="{% if SymbolMode == 'Geographic' %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-26.1-R2500-60E1-BX-1-Metric{% else %}NO-BN-2D-JBTKO_SPV-FORBINDELSE-SPORVEKSEL-GENERELL-1-Schematic{% endif %}"
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfRightSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 		</InsertPointObject>
 
 		<!-- Track and embankment viewpoint's symbol -->
@@ -1369,7 +1369,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1377,7 +1377,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1385,7 +1385,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1393,7 +1393,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1401,7 +1401,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 		
@@ -1409,7 +1409,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1417,7 +1417,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 
@@ -1425,7 +1425,7 @@
                 DefaultSnapMode="Alignment" SnapToAlignment="true" SnapDistance="4e-4" >
 			<OwnAlignmentTargetSpace>spor</OwnAlignmentTargetSpace>
 			<JigSymbolAppearance EnableDirectionSetting="true" MirrorAboutJigYAxisIfLeftSideOfAlignment="true" />
-			<SetValue Key="KmStigerMotVenstre" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
+			<SetValue Key="MileageIncreasesTowardsLeft" Value="{{alignmentRotation | minus:ucsRotation | cosisnegative}}" />
 			<SetValue Key="NormalPosition" Value="{% if RightSided %}{% if dir == 'up' %}Left{% else %}Right{% endif %}{% else %}{% if dir == 'up' %}Right{% else %}Left{% endif %}{% endif %}" />
 		</InsertPointObject>
 


### PR DESCRIPTION
# Standard Properties Changes — `match-standard-properties-with-2026.1-dna`

Aligns the NO-BN 2021.a standard property definitions (`DNA/_SRC/NO-BN-StandardProperties.xml`)
and all references to them with the 2026.1 DNA naming/structure.

Closes #288

## 1. Property renames (propagated across all DNA `_SRC` files)

- **`KmStigerMotVenstre` → `MileageIncreasesTowardsLeft`** — renamed the `CustomAttribute`,
  its `xpp:define` macro, the `PropertyOverride`, and **110 references across 8 files**
  (Balises, Labels, TrackConnections, CommonObjects, TrackAndWaysideObjects, OcsMasts,
  SignalingObjects, OcsVariousObjects). DisplayName set to `"Profilverdi stiger mot venstre"`.
- **`Yokemounted` → `PortalMounted`** — renamed the `CustomAttribute`, its macro, and all
  references across Signals, BoardsAndPoles, and Lua. DisplayName `"Åkmontert" → "Portalmontert"`;
  description updated from "suspended from a yoke" to "suspended from a portal". The two
  `RelativeElevation` Lua formulas that tested `Yokemounted` now test `PortalMounted`.

## 2. New PropertyCategories

- **`Text Attributes`** (DisplayName `"Tekstattributter"`, collapsed).
- **`2D Projection`** (DisplayName `"2D projeksjon"`, collapsed).
- **`Misc`** — removed its DisplayName (`"railML og annet"`); category is now unnamed.

## 3. `General` category — added/updated overrides

- `Variant` — added DisplayName `"Variant"`.
- **New:** `ProxySymbolBlockName` (`"Proxy blokknavn for 2D-symbolet"`).
- **New:** `ProxySymbolAttDefText` (`"Proxy tekst i 2D-symbolet"`).
- **New:** `Seq` (`"Sekvensnummer"`) — moved here from `Local variables`.
- **New:** `Tag` (`"Banedata objekt-ID"`).
- **New:** `description` (`"Beskrivelse"`).

## 4. `Aligned object` category — restructured & renamed (units added)

- `Alignment` — `"Egen linje" → "Linje"`.
- `TargetAlignment` — `"Tilstøtende linje" → "Avvikende / tilstøtende linje"` (moved up).
- `SideOfAlignment` — now `Suppressed="true"`.
- `Mileage` — `"Profil egen linje (PEL)" → "Profil langs linje [m]"`.
- `ReferenceMileage` — `"Km" → "Km iht. referanselinje [m]"`.
- **`pos` → `DistanceAlong`** — `"Plassering fra start i egen linje" → "Avstand fra linjestart [m]"`.
- **`RelativeElevation` → `VerticalOffset`** — `"Høyde over egen linje" → "Høyde over linje [m]"`.
- `DistanceToAlignment` — `"Sideavsett fra egen linje" → "Avstand til linje [m]"`.
- **New:** `LateralOffset` (`"Sideavsett fra linje [m]"`).
- **New:** `LongitudinalOffset` (`"Offset langs line [m]"`).
- `AngularOffset` — **moved into this category from `3D`**; DisplayName `"3D Angular offset" → "Vinkel-tillegg"`
  (the `CustomAttribute` definition's `Category` also changed `3D → Aligned object`).

## 5. `Presentation` category

- `KmStigerMotVenstre` override replaced by **`MileageIncreasesTowardsLeft`** with DisplayName
  `"Profilverdi stiger mot venstre"`.

## 6. `3D` category

- `geoCoord` — `"Koordinater" → "Innsettingspunkt i WCS (øst, nord, h.o.h.)"`.
- **New:** `Layer3D` (`"3D-geometri lag"`).
- `AngularOffset` removed from here (moved to `Aligned object`).

## 7. `Local variables` category

- Removed `Seq` (moved to `General`).

## 8. `Formulas` category

- `LuaExpressions` — DisplayName `"Lua uttrykk" → "Lua formler"`.

## 9. `Connections` category

- `ContinuingWithBegin` — `"Påfølgende spor starter her" → "Påfølgende linje starter her"`.
- `ExtendingFromEnd` — `"Foregående spor ender her" → "Foregående linje ender her"`.