### PR TITLE
Update Copy or move objects to neighbor track

### DIFF
--- a/NO-BN/Lua/Scripts/FE/Kopiere eller flytte objekter til annet spor på samme Km/Copy or move objects to neighbor track.lua
+++ b/NO-BN/Lua/Scripts/FE/Kopiere eller flytte objekter til annet spor på samme Km/Copy or move objects to neighbor track.lua
@@ -32,7 +32,6 @@ end
 
 local actionName = option == _COPY_ and "copied" or "moved" --Used in prompts
 
-
 --Select object(s) to copy or move:
 local objects = {}
 local obj

--- a/NO-BN/Lua/Scripts/FE/Kopiere eller flytte objekter til annet spor på samme Km/Copy or move objects to neighbor track.lua
+++ b/NO-BN/Lua/Scripts/FE/Kopiere eller flytte objekter til annet spor på samme Km/Copy or move objects to neighbor track.lua
@@ -1,5 +1,5 @@
 local _HEADER_ = "Copy or move objects to neighbor track"
-local _VERSION_ = "2026-07-03_000 CLFEY Created."
+local _VERSION_ = "2026-07-18_000 CLFEY Created."
 
 local _USAGE_ = [[
 1) Click somewhere in modelspace to activate the script.
@@ -14,13 +14,24 @@ Relations internal to the selected group of objects will be preserved.
 local _OK_ = "OK"
 local _COPY_ = "Copy object group"
 local _MOVE_ = "Move object group"
+local _TERMINATE_ = "Terminate"
+local _ESC_ = nil --askForKeyword() return nil when ESC is pressed or if the the user clicks the 'x' in upper right corner
+
 local _RCTYPE_RAILWAY_TRACK_ = "JBTKO_SPO Spor"
 
 local option
 repeat
-	option = askForKeyword(_USAGE_, {_COPY_, _MOVE_}, _HEADER_)
-until option == _COPY_ or option == _MOVE_
+	option = askForKeyword(_USAGE_, {_COPY_, _MOVE_, _TERMINATE_}, _HEADER_)
+until option == _COPY_ or option == _MOVE_ or option == _TERMINATE_ or option == _ESC_
+
+if option == _TERMINATE_ or option == _ESC_ then
+	write("Terminated.")
+	return
+end
+
+
 local actionName = option == _COPY_ and "copied" or "moved" --Used in prompts
+
 
 --Select object(s) to copy or move:
 local objects = {}
@@ -69,21 +80,30 @@ local sign = getLinearAddress(p, trk).lateralOffset > 0 and 1 or -1
 local source = {}
 for k, v in pairs(objects) do table.insert(source, v) end
 setSelectionSet(getCollectionFromTable(source))
---Copy previous selection set to same position, while preserving relations within the selection set:
-runCommand("_COPY _P _M _S '(0 0 0) '(0 0 0) _E ")
+if option == _COPY_ then 
+	--Copy previous selection set to same position, while preserving relations within the selection set:
+	runCommand("_COPY _P _M _S '(0 0 0) '(0 0 0) _E ")
+end
 
 for k, v in pairs(objects) do
-	--Find the clones, move to target alignment:
-	clone = getNearbyPointObjects2D(v, v.RcType, 0.1):filter(function (x) return x.Variant == v.Variant and x.Dir == v.Dir end)[0]
-	local lateralOffset = clone.LateralOffset
-	clone.Alignment = trk.id --attach to target alignment - must assign using the ID (illogical)
-	if getLuaFormulaString(clone, "DistanceToAlignment") then
-		clone.DistanceToAlignment = "=" --remove formula on DistanceToAlignment, if any
+	--Move items to new target alignment and side of alignment:
+	if option == _COPY_ then
+		--operate on the cloned item (search around original items for their clone)
+		item = getNearbyPointObjects2D(v, v.RcType, 0.1):filter(function (x) return x.Variant == v.Variant and x.Dir == v.Dir end)[0]
+	else
+		--option == _MOVE_, operate on the item itself
+		item = v
 	end
-	if getLuaFormulaString(clone, "LateralOffset") then
-		clone.DistanceToAlignment = "=" --remove formula on DistanceToAlignment, if any
+	local lateralOffset = item.LateralOffset
+	item.Alignment = trk.id --attach to target alignment - must assign using the ID (an illogical API...)
+	if getLuaFormulaString(item, "DistanceToAlignment") then
+		item.DistanceToAlignment = "=" --remove formula on DistanceToAlignment, if any
 	end
-	clone.LateralOffset = sign * math.abs(lateralOffset)
+	if getLuaFormulaString(item, "LateralOffset") then
+		item.DistanceToAlignment = "=" --remove formula on DistanceToAlignment, if any
+	end
+	item.LateralOffset = sign * math.abs(lateralOffset)
 end
 
 write("Done.")
+

--- a/NO-BN/Lua/Scripts/FE/Kopiere eller flytte objekter til annet spor på samme Km/Copy or move objects to neighbor track.lua
+++ b/NO-BN/Lua/Scripts/FE/Kopiere eller flytte objekter til annet spor på samme Km/Copy or move objects to neighbor track.lua
@@ -15,7 +15,7 @@ local _OK_ = "OK"
 local _COPY_ = "Copy object group"
 local _MOVE_ = "Move object group"
 local _TERMINATE_ = "Terminate"
-local _ESC_ = nil --askForKeyword() return nil when ESC is pressed or if the the user clicks the 'x' in upper right corner
+local _ESC_ = nil --askForKeyword() returns nil when ESC is pressed or if the the user clicks the 'x' in upper right corner
 
 local _RCTYPE_RAILWAY_TRACK_ = "JBTKO_SPO Spor"
 


### PR DESCRIPTION
## Summary

Fixes a bug in the "Copy or move objects to neighbor track" Lua script where the **Move** option actually duplicated the selected objects (via `_COPY`) instead of moving them in place, leaving unwanted copies behind. Also adds a way to cleanly cancel the script from the initial prompt.

## Changes

- **Fixed Move behavior**: The `_COPY` AutoCAD command is now only invoked when the user picks "Copy object group". Previously it ran unconditionally, so choosing "Move" still cloned the objects instead of relocating the originals.
- **Move now operates on the original objects**: For the Move path, the script acts directly on the selected item (`v`) rather than searching for a nearby clone. For Copy, it still locates the freshly-created clone via `getNearbyPointObjects2D`. The shared variable was renamed from `clone` to `item` to reflect this.
- **Added a Terminate option**: The initial `askForKeyword` prompt now offers "Terminate" alongside "Copy object group" / "Move object group", and pressing ESC or clicking the dialog's close button is also handled — both now exit the script cleanly with a `"Terminated."` message instead of looping indefinitely.

## Notes

Closes #301 